### PR TITLE
remove build job from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,28 +7,7 @@ on:
       - 'v*'
   pull_request:
 
-# The build job caches build artifacts which avoids duplicating work between the
-# unit and API tests.
 jobs:
-  build:
-    name: Build the connector
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-
-      - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v4
-
-      - name: Link Cachix 🔌
-        uses: cachix/cachix-action@v12
-        with:
-          name: '${{ vars.CACHIX_CACHE_NAME }}'
-          authToken: '${{ secrets.CACHIX_CACHE_AUTH_TOKEN }}'
-
-      - name: build the crate 🔨
-        run: nix build --print-build-logs
-
   unit_tests:
     name: Unit Tests
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   unit_tests:
     name: Unit Tests
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
It's not actually helping cache performance, particularly since we don't have API tests in this workflow anymore.