### PR TITLE
switch configuration types to maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "configuration",
  "futures-util",
  "indexmap 1.9.3",
+ "itertools 0.12.1",
  "mongodb",
  "mongodb-agent-common",
  "mongodb-support",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.80"
 clap = { version = "4.5.1", features = ["derive", "env"] }
 futures-util = "0.3.28"
 indexmap = { version = "1", features = ["serde"] } # must match the version that ndc-client uses
+itertools = "^0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.113", features = ["raw_value"] }
 thiserror = "1.0.57"

--- a/crates/cli/src/introspection/sampling.rs
+++ b/crates/cli/src/introspection/sampling.rs
@@ -1,14 +1,19 @@
+use std::collections::BTreeMap;
+
 use super::type_unification::{
     unify_object_types, unify_schema, unify_type, TypeUnificationContext, TypeUnificationResult,
 };
 use configuration::{
-    schema::{Collection, ObjectField, ObjectType, Type},
-    Schema,
+    schema::{self, Type},
+    Schema, WithName,
 };
 use futures_util::TryStreamExt;
 use mongodb::bson::{doc, Bson, Document};
 use mongodb_agent_common::interface_types::MongoConfig;
 use mongodb_support::BsonScalarType::{self, *};
+
+type ObjectField = WithName<schema::ObjectField>;
+type ObjectType = WithName<schema::ObjectType>;
 
 /// Sample from all collections in the database and return a Schema.
 /// Return an error if there are any errors accessing the database
@@ -19,8 +24,8 @@ pub async fn sample_schema_from_db(
     config: &MongoConfig,
 ) -> anyhow::Result<Schema> {
     let mut schema = Schema {
-        collections: vec![],
-        object_types: vec![],
+        collections: BTreeMap::new(),
+        object_types: BTreeMap::new(),
     };
     let db = config.client.database(&config.database);
     let mut collections_cursor = db.list_collections(None, None).await?;
@@ -54,15 +59,17 @@ async fn sample_schema_from_collection(
             unify_object_types(collected_object_types, object_types)?
         };
     }
-    let collection_info = Collection {
-        name: collection_name.to_string(),
-        description: None,
-        r#type: collection_name.to_string(),
-    };
+    let collection_info = WithName::named(
+        collection_name.to_string(),
+        schema::Collection {
+            description: None,
+            r#type: collection_name.to_string(),
+        },
+    );
 
     Ok(Schema {
-        collections: vec![collection_info],
-        object_types: collected_object_types,
+        collections: WithName::into_map([collection_info]),
+        object_types: WithName::into_map(collected_object_types),
     })
 }
 
@@ -83,11 +90,13 @@ fn make_object_type(
         (object_type_defs.concat(), object_fields)
     };
 
-    let object_type = ObjectType {
-        name: object_type_name.to_string(),
-        description: None,
-        fields: object_fields,
-    };
+    let object_type = WithName::named(
+        object_type_name.to_string(),
+        schema::ObjectType {
+            description: None,
+            fields: WithName::into_map(object_fields),
+        },
+    );
 
     object_type_defs.push(object_type);
     Ok(object_type_defs)
@@ -101,11 +110,13 @@ fn make_object_field(
     let object_type_name = format!("{type_prefix}{field_name}");
     let (collected_otds, field_type) = make_field_type(&object_type_name, field_name, field_value)?;
 
-    let object_field = ObjectField {
-        name: field_name.to_owned(),
-        description: None,
-        r#type: field_type,
-    };
+    let object_field = WithName::named(
+        field_name.to_owned(),
+        schema::ObjectField {
+            description: None,
+            r#type: field_type,
+        },
+    );
 
     Ok((collected_otds, object_field))
 }
@@ -164,7 +175,12 @@ fn make_field_type(
 
 #[cfg(test)]
 mod tests {
-    use configuration::schema::{ObjectField, ObjectType, Type};
+    use std::collections::BTreeMap;
+
+    use configuration::{
+        schema::{ObjectField, ObjectType, Type},
+        WithName,
+    };
     use mongodb::bson::doc;
     use mongodb_support::BsonScalarType;
 
@@ -176,24 +192,30 @@ mod tests {
     fn simple_doc() -> Result<(), anyhow::Error> {
         let object_name = "foo";
         let doc = doc! {"my_int": 1, "my_string": "two"};
-        let result = make_object_type(object_name, &doc);
+        let result = make_object_type(object_name, &doc).map(WithName::into_map::<BTreeMap<_, _>>);
 
-        let expected = Ok(vec![ObjectType {
-            name: object_name.to_owned(),
-            fields: vec![
-                ObjectField {
-                    name: "my_int".to_owned(),
-                    r#type: Type::Scalar(BsonScalarType::Int),
-                    description: None,
-                },
-                ObjectField {
-                    name: "my_string".to_owned(),
-                    r#type: Type::Scalar(BsonScalarType::String),
-                    description: None,
-                },
-            ],
-            description: None,
-        }]);
+        let expected = Ok(BTreeMap::from([(
+            object_name.to_owned(),
+            ObjectType {
+                fields: BTreeMap::from([
+                    (
+                        "my_int".to_owned(),
+                        ObjectField {
+                            r#type: Type::Scalar(BsonScalarType::Int),
+                            description: None,
+                        },
+                    ),
+                    (
+                        "my_string".to_owned(),
+                        ObjectField {
+                            r#type: Type::Scalar(BsonScalarType::String),
+                            description: None,
+                        },
+                    ),
+                ]),
+                description: None,
+            },
+        )]));
 
         assert_eq!(expected, result);
 
@@ -204,40 +226,56 @@ mod tests {
     fn array_of_objects() -> Result<(), anyhow::Error> {
         let object_name = "foo";
         let doc = doc! {"my_array": [{"foo": 42, "bar": ""}, {"bar": "wut", "baz": 3.77}]};
-        let result = make_object_type(object_name, &doc);
+        let result = make_object_type(object_name, &doc).map(WithName::into_map::<BTreeMap<_, _>>);
 
-        let expected = Ok(vec![
-            ObjectType {
-                name: "foo_my_array".to_owned(),
-                fields: vec![
-                    ObjectField {
-                        name: "foo".to_owned(),
-                        r#type: Type::Nullable(Box::new(Type::Scalar(BsonScalarType::Int))),
-                        description: None,
-                    },
-                    ObjectField {
-                        name: "bar".to_owned(),
-                        r#type: Type::Scalar(BsonScalarType::String),
-                        description: None,
-                    },
-                    ObjectField {
-                        name: "baz".to_owned(),
-                        r#type: Type::Nullable(Box::new(Type::Scalar(BsonScalarType::Double))),
-                        description: None,
-                    },
-                ],
-                description: None,
-            },
-            ObjectType {
-                name: object_name.to_owned(),
-                fields: vec![ObjectField {
-                    name: "my_array".to_owned(),
-                    r#type: Type::ArrayOf(Box::new(Type::Object("foo_my_array".to_owned()))),
+        let expected = Ok(BTreeMap::from([
+            (
+                "foo_my_array".to_owned(),
+                ObjectType {
+                    fields: BTreeMap::from([
+                        (
+                            "foo".to_owned(),
+                            ObjectField {
+                                r#type: Type::Nullable(Box::new(Type::Scalar(BsonScalarType::Int))),
+                                description: None,
+                            },
+                        ),
+                        (
+                            "bar".to_owned(),
+                            ObjectField {
+                                r#type: Type::Scalar(BsonScalarType::String),
+                                description: None,
+                            },
+                        ),
+                        (
+                            "baz".to_owned(),
+                            ObjectField {
+                                r#type: Type::Nullable(Box::new(Type::Scalar(
+                                    BsonScalarType::Double,
+                                ))),
+                                description: None,
+                            },
+                        ),
+                    ]),
                     description: None,
-                }],
-                description: None,
-            },
-        ]);
+                },
+            ),
+            (
+                object_name.to_owned(),
+                ObjectType {
+                    fields: BTreeMap::from([(
+                        "my_array".to_owned(),
+                        ObjectField {
+                            r#type: Type::ArrayOf(Box::new(Type::Object(
+                                "foo_my_array".to_owned(),
+                            ))),
+                            description: None,
+                        },
+                    )]),
+                    description: None,
+                },
+            ),
+        ]));
 
         assert_eq!(expected, result);
 

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -1,9 +1,11 @@
 mod configuration;
-pub mod schema;
-pub mod native_queries;
 mod directory;
+pub mod native_queries;
+pub mod schema;
+mod with_name;
 
 pub use crate::configuration::Configuration;
-pub use crate::schema::Schema;
 pub use crate::directory::read_directory;
 pub use crate::directory::write_directory;
+pub use crate::schema::Schema;
+pub use crate::with_name::{WithName, WithNameRef};

--- a/crates/configuration/src/native_queries.rs
+++ b/crates/configuration/src/native_queries.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use mongodb::{bson, options::SelectionCriteria};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -9,14 +11,11 @@ use crate::schema::{ObjectField, ObjectType, Type};
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NativeQuery {
-    /// Name that will be used to identify the query in your data graph
-    pub name: String,
-
     /// You may define object types here to reference in `result_type`. Any types defined here will
     /// be merged with the definitions in `schema.json`. This allows you to maintain hand-written
     /// types for native queries without having to edit a generated `schema.json` file.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub object_types: Vec<ObjectType>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub object_types: BTreeMap<String, ObjectType>,
 
     /// Type of data returned by the query. You may reference object types defined in the
     /// `object_types` list in this definition, or you may reference object types from
@@ -25,7 +24,7 @@ pub struct NativeQuery {
 
     /// Arguments for per-query customization
     #[serde(default)]
-    pub arguments: Vec<ObjectField>,
+    pub arguments: BTreeMap<String, ObjectField>,
 
     /// Command to run expressed as a BSON document
     #[schemars(with = "Object")]

--- a/crates/configuration/src/schema/mod.rs
+++ b/crates/configuration/src/schema/mod.rs
@@ -1,7 +1,11 @@
 mod database;
 
+use std::collections::BTreeMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+use crate::{WithName, WithNameRef};
 
 pub use self::database::{Collection, ObjectField, ObjectType, Type};
 
@@ -9,7 +13,33 @@ pub use self::database::{Collection, ObjectField, ObjectType, Type};
 #[serde(rename_all = "camelCase")]
 pub struct Schema {
     #[serde(default)]
-    pub collections: Vec<Collection>,
+    pub collections: BTreeMap<String, Collection>,
     #[serde(default)]
-    pub object_types: Vec<ObjectType>,
+    pub object_types: BTreeMap<String, ObjectType>,
+}
+
+impl Schema {
+    pub fn into_named_collections(self) -> impl Iterator<Item = WithName<Collection>> {
+        self.collections
+            .into_iter()
+            .map(|(name, field)| WithName::named(name, field))
+    }
+
+    pub fn into_named_object_types(self) -> impl Iterator<Item = WithName<ObjectType>> {
+        self.object_types
+            .into_iter()
+            .map(|(name, field)| WithName::named(name, field))
+    }
+
+    pub fn named_collections(&self) -> impl Iterator<Item = WithNameRef<'_, Collection>> {
+        self.collections
+            .iter()
+            .map(|(name, field)| WithNameRef::named(name, field))
+    }
+
+    pub fn named_object_types(&self) -> impl Iterator<Item = WithNameRef<'_, ObjectType>> {
+        self.object_types
+            .iter()
+            .map(|(name, field)| WithNameRef::named(name, field))
+    }
 }

--- a/crates/configuration/src/with_name.rs
+++ b/crates/configuration/src/with_name.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+/// Helper for working with serialized formats of named values. This is for cases where we want to
+/// deserialize to a map where names are stored as map keys. But in serialized form the name may be
+/// an inline field.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
+pub struct WithName<T> {
+    pub name: String,
+    #[serde(flatten)]
+    pub value: T,
+}
+
+impl<T> WithName<T> {
+    pub fn into_map<Map>(values: impl IntoIterator<Item = WithName<T>>) -> Map
+    where
+        Map: FromIterator<(String, T)>,
+    {
+        values
+            .into_iter()
+            .map(Self::into_name_value_pair)
+            .collect::<Map>()
+    }
+
+    pub fn into_name_value_pair(self) -> (String, T) {
+        (self.name, self.value)
+    }
+
+    pub fn named(name: impl ToString, value: T) -> Self {
+        WithName {
+            name: name.to_string(),
+            value,
+        }
+    }
+
+    pub fn as_ref<R>(&self) -> WithNameRef<'_, R>
+    where
+        T: AsRef<R>,
+    {
+        WithNameRef::named(&self.name, self.value.as_ref())
+    }
+}
+
+impl<T> From<WithName<T>> for (String, T) {
+    fn from(value: WithName<T>) -> Self {
+        value.into_name_value_pair()
+    }
+}
+
+impl<T> From<(String, T)> for WithName<T> {
+    fn from((name, value): (String, T)) -> Self {
+        WithName::named(name, value)
+    }
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct WithNameRef<'a, T> {
+    pub name: &'a str,
+    pub value: &'a T,
+}
+
+impl<'a, T> WithNameRef<'a, T> {
+    pub fn named<'b>(name: &'b str, value: &'b T) -> WithNameRef<'b, T> {
+        WithNameRef { name, value }
+    }
+
+    pub fn to_owned<R>(&self) -> WithName<R>
+    where
+        T: ToOwned<Owned = R>,
+    {
+        WithName::named(self.name.to_owned(), self.value.to_owned())
+    }
+}
+
+impl<'a, T, R> From<&'a WithName<T>> for WithNameRef<'a, R>
+where
+    T: AsRef<R>,
+{
+    fn from(value: &'a WithName<T>) -> Self {
+        value.as_ref()
+    }
+}

--- a/crates/mongodb-agent-common/src/interface_types/mongo_config.rs
+++ b/crates/mongodb-agent-common/src/interface_types/mongo_config.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use configuration::native_queries::NativeQuery;
 use mongodb::Client;
 
@@ -8,5 +10,5 @@ pub struct MongoConfig {
     /// Name of the database to connect to
     pub database: String,
 
-    pub native_queries: Vec<NativeQuery>,
+    pub native_queries: BTreeMap<String, NativeQuery>,
 }

--- a/crates/mongodb-agent-common/src/query/mod.rs
+++ b/crates/mongodb-agent-common/src/query/mod.rs
@@ -36,10 +36,15 @@ pub async fn handle_query_request(
     let database = config.client.database(&config.database);
 
     let target = &query_request.target;
-    if let Some(native_query) = config.native_queries.iter().find(|query| {
-        let target_name = target.name();
-        target_name.len() == 1 && target_name[0] == query.name
-    }) {
+    let target_name = {
+        let name = target.name();
+        if name.len() == 1 {
+            Some(&name[0])
+        } else {
+            None
+        }
+    };
+    if let Some(native_query) = target_name.and_then(|name| config.native_queries.get(name)) {
         return handle_native_query_request(native_query.clone(), database).await;
     }
 

--- a/crates/mongodb-connector/src/mutation.rs
+++ b/crates/mongodb-connector/src/mutation.rs
@@ -56,13 +56,17 @@ fn look_up_procedures(
         .into_iter()
         .map(|operation| match operation {
             MutationOperation::Procedure {
-                name, arguments, ..
+                name: procedure_name,
+                arguments,
+                ..
             } => {
                 let native_query = config
                     .native_queries
                     .iter()
-                    .find(|native_query| native_query.name == name);
-                native_query.ok_or(name).map(|nq| Job::new(nq, arguments))
+                    .find(|(native_query_name, _)| *native_query_name == &procedure_name);
+                native_query
+                    .ok_or(procedure_name)
+                    .map(|(_, nq)| Job::new(nq, arguments))
             }
         })
         .partition_result();

--- a/fixtures/connector/chinook/native_queries/hello.yaml
+++ b/fixtures/connector/chinook/native_queries/hello.yaml
@@ -1,11 +1,11 @@
 name: hello
 description: Example of a read-only native query
 objectTypes:
-  - name: HelloResult
+  HelloResult:
     fields:
-      - name: ok
+      ok:
         type: !scalar int
-      - name: readOnly
+      readOnly:
         type: !scalar bool
       # There are more fields but you get the idea
 resultType: !object HelloResult

--- a/fixtures/connector/chinook/native_queries/insert_artist.yaml
+++ b/fixtures/connector/chinook/native_queries/insert_artist.yaml
@@ -1,11 +1,11 @@
 name: insertArtist
 description: Example of a database update using a native query
 objectTypes:
-  - name: InsertArtist
+  InsertArtist:
     fields:
-      - name: ok
+      ok:
         type: !scalar int
-      - name: n
+      n:
         type: !scalar int
 resultType: !object InsertArtist
 # TODO: implement arguments instead of hard-coding inputs

--- a/fixtures/connector/chinook/schema.json
+++ b/fixtures/connector/chinook/schema.json
@@ -1,742 +1,555 @@
 {
-  "collections": [
-    {
-      "name": "Invoice",
-      "type": "Invoice",
-      "description": null
-    },
-    {
-      "name": "Track",
-      "type": "Track",
-      "description": null
-    },
-    {
-      "name": "MediaType",
-      "type": "MediaType",
-      "description": null
-    },
-    {
-      "name": "InvoiceLine",
-      "type": "InvoiceLine",
-      "description": null
-    },
-    {
-      "name": "Employee",
-      "type": "Employee",
-      "description": null
-    },
-    {
-      "name": "PlaylistTrack",
-      "type": "PlaylistTrack",
-      "description": null
-    },
-    {
-      "name": "Album",
+  "collections": {
+    "Album": {
       "type": "Album",
       "description": null
     },
-    {
-      "name": "Genre",
-      "type": "Genre",
-      "description": null
-    },
-    {
-      "name": "Artist",
+    "Artist": {
       "type": "Artist",
       "description": null
     },
-    {
-      "name": "Playlist",
+    "Customer": {
+      "type": "Customer",
+      "description": null
+    },
+    "Employee": {
+      "type": "Employee",
+      "description": null
+    },
+    "Genre": {
+      "type": "Genre",
+      "description": null
+    },
+    "Invoice": {
+      "type": "Invoice",
+      "description": null
+    },
+    "InvoiceLine": {
+      "type": "InvoiceLine",
+      "description": null
+    },
+    "MediaType": {
+      "type": "MediaType",
+      "description": null
+    },
+    "Playlist": {
       "type": "Playlist",
       "description": null
     },
-    {
-      "name": "Customer",
-      "type": "Customer",
+    "PlaylistTrack": {
+      "type": "PlaylistTrack",
+      "description": null
+    },
+    "Track": {
+      "type": "Track",
       "description": null
     }
-  ],
-  "objectTypes": [
-    {
-      "name": "Invoice",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BillingAddress",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BillingCity",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BillingCountry",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BillingPostalCode",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BillingState",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "CustomerId",
+  },
+  "objectTypes": {
+    "Album": {
+      "fields": {
+        "AlbumId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "InvoiceDate",
+        "ArtistId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Title": {
           "type": {
             "scalar": "string"
           },
           "description": null
         },
-        {
-          "name": "InvoiceId",
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Artist": {
+      "fields": {
+        "ArtistId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "Total",
+        "Name": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Customer": {
+      "fields": {
+        "Address": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "City": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Company": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Country": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "CustomerId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Email": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Fax": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "FirstName": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "LastName": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Phone": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "PostalCode": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "State": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "SupportRepId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Employee": {
+      "fields": {
+        "Address": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "BirthDate": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "City": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Country": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Email": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "EmployeeId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Fax": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "FirstName": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "HireDate": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "LastName": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Phone": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "PostalCode": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "ReportsTo": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "State": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "Title": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Genre": {
+      "fields": {
+        "GenreId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Name": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Invoice": {
+      "fields": {
+        "BillingAddress": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "BillingCity": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "BillingCountry": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "BillingPostalCode": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "BillingState": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "CustomerId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "InvoiceDate": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "InvoiceId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Total": {
           "type": {
             "scalar": "double"
           },
           "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
         }
-      ],
-      "description": "Object type for collection Invoice"
+      },
+      "description": null
     },
-    {
-      "name": "Track",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "AlbumId",
-          "type": {
-            "nullable": {
-              "scalar": "int"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Bytes",
-          "type": {
-            "nullable": {
-              "scalar": "int"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Composer",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "GenreId",
-          "type": {
-            "nullable": {
-              "scalar": "int"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "MediaTypeId",
+    "InvoiceLine": {
+      "fields": {
+        "InvoiceId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "Milliseconds",
+        "InvoiceLineId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "Name",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "TrackId",
+        "Quantity": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "UnitPrice",
+        "TrackId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "UnitPrice": {
           "type": {
             "scalar": "double"
           },
           "description": null
-        }
-      ],
-      "description": "Object type for collection Track"
-    },
-    {
-      "name": "MediaType",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
         },
-        {
-          "name": "MediaTypeId",
+        "_id": {
           "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Name",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
+            "scalar": "objectId"
           },
           "description": null
         }
-      ],
-      "description": "Object type for collection MediaType"
+      },
+      "description": null
     },
-    {
-      "name": "InvoiceLine",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "InvoiceId",
+    "MediaType": {
+      "fields": {
+        "MediaTypeId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "InvoiceLineId",
+        "Name": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Playlist": {
+      "fields": {
+        "Name": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "PlaylistId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "Quantity",
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "PlaylistTrack": {
+      "fields": {
+        "PlaylistId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "TrackId",
+        "TrackId": {
           "type": {
             "scalar": "int"
           },
           "description": null
         },
-        {
-          "name": "UnitPrice",
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          },
+          "description": null
+        }
+      },
+      "description": null
+    },
+    "Track": {
+      "fields": {
+        "AlbumId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Bytes": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Composer": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "GenreId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "MediaTypeId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Milliseconds": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "Name": {
+          "type": {
+            "scalar": "string"
+          },
+          "description": null
+        },
+        "TrackId": {
+          "type": {
+            "scalar": "int"
+          },
+          "description": null
+        },
+        "UnitPrice": {
           "type": {
             "scalar": "double"
           },
           "description": null
-        }
-      ],
-      "description": "Object type for collection InvoiceLine"
-    },
-    {
-      "name": "Employee",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
         },
-        {
-          "name": "Address",
+        "_id": {
           "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "BirthDate",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "City",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Country",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Email",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "EmployeeId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Fax",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "FirstName",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "HireDate",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "LastName",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "Phone",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "PostalCode",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "ReportsTo",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "State",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Title",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
+            "scalar": "objectId"
           },
           "description": null
         }
-      ],
-      "description": "Object type for collection Employee"
-    },
-    {
-      "name": "PlaylistTrack",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "PlaylistId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "TrackId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection PlaylistTrack"
-    },
-    {
-      "name": "Album",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "AlbumId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "ArtistId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Title",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection Album"
-    },
-    {
-      "name": "Genre",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "GenreId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Name",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection Genre"
-    },
-    {
-      "name": "Artist",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "ArtistId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Name",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection Artist"
-    },
-    {
-      "name": "Playlist",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Name",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "PlaylistId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection Playlist"
-    },
-    {
-      "name": "Customer",
-      "fields": [
-        {
-          "name": "_id",
-          "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Address",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "City",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Company",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "Country",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "CustomerId",
-          "type": {
-            "scalar": "int"
-          },
-          "description": null
-        },
-        {
-          "name": "Email",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "Fax",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "FirstName",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "LastName",
-          "type": {
-            "scalar": "string"
-          },
-          "description": null
-        },
-        {
-          "name": "Phone",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "PostalCode",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "State",
-          "type": {
-            "nullable": {
-              "scalar": "string"
-            }
-          },
-          "description": null
-        },
-        {
-          "name": "SupportRepId",
-          "type": {
-            "nullable": {
-              "scalar": "int"
-            }
-          },
-          "description": null
-        }
-      ],
-      "description": "Object type for collection Customer"
+      },
+      "description": null
     }
-  ]
+  }
 }


### PR DESCRIPTION
In some earlier feedback @dmoverton pointed out it would be better to store native queries in maps, as opposed to vecs. I thought the same logic would apply to some of the other configuration fields. It's also been bugging me that the configuration formats didn't match pattern in ddn and ndc-postgres in that we were using lists of named objects instead of maps.

I switched over some types from `Vec<StructWithNameField>` to `BTreeMap<String, StructWithoutNameField>`. To smooth things out I also added a `WithName` type that can wrap any struct, and adds a `name` field that appears at the same level as the underlying struct's fields in serialized formats. That lets us deserialize either without a name (for example if we're getting names from map keys in `schema.json` instead of from map value fields), or with a name (like if we split up schema configuration to put info for each collection into it's own file, we'll want to read the name from a field in the file.) I used that method to update `read_subdir_configs` in `directory.rs` so that it automatically grabs a name from each file.

The changes ended up being more extensive than I'd hoped so let me know if it's too much. But since this changes configuration formats I thought if we want to make this change it's better not to wait.

https://hasurahq.atlassian.net/browse/MDB-91