### PR TITLE
Separate schema files for each collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This changelog documents the changes between release versions.
 
 ## [Unreleased]
-Changes to be included in the next upcoming release
+- Use separate schema files for each collection
+- Don't sample from collections that already have a schema
 
 ## [0.0.2] - 2024-03-26
 - Rename CLI plugin to ndc-mongodb ([PR #13](https://github.com/hasura/ndc-mongodb/pull/13))

--- a/crates/cli/src/introspection/type_unification.rs
+++ b/crates/cli/src/introspection/type_unification.rs
@@ -4,7 +4,7 @@
 ///
 use configuration::{
     schema::{self, Type},
-    Schema, WithName,
+    WithName,
 };
 use indexmap::IndexMap;
 use itertools::Itertools as _;
@@ -253,24 +253,6 @@ pub fn unify_object_types(
     let merged_type_map = align_with_result(type_map_a, type_map_b, Ok, Ok, unify_object_type)?;
 
     Ok(merged_type_map.into_values().collect())
-}
-
-/// Unify two schemas. Assumes that the schemas describe mutually exclusive sets of collections.
-pub fn unify_schema(schema_a: Schema, schema_b: Schema) -> Schema {
-    let collections = schema_a
-        .collections
-        .into_iter()
-        .chain(schema_b.collections)
-        .collect();
-    let object_types = schema_a
-        .object_types
-        .into_iter()
-        .chain(schema_b.object_types)
-        .collect();
-    Schema {
-        collections,
-        object_types,
-    }
 }
 
 #[cfg(test)]

--- a/crates/cli/src/introspection/validation_schema.rs
+++ b/crates/cli/src/introspection/validation_schema.rs
@@ -24,9 +24,9 @@ pub async fn get_metadata_from_validation_schema(
 
     let schemas: Vec<WithName<Schema>> = collections_cursor
         .into_stream()
-        .filter_map(
-            |collection_spec| -> Option<WithName<Schema>> {
-                let collection_spec_value = collection_spec.ok()?;
+        .map(
+            |collection_spec| -> Result<WithName<Schema>, MongoAgentError> {
+                let collection_spec_value = collection_spec?;
                 let name = &collection_spec_value.name;
                 let schema_bson_option = collection_spec_value
                     .options
@@ -34,11 +34,27 @@ pub async fn get_metadata_from_validation_schema(
                     .as_ref()
                     .and_then(|x| x.get("$jsonSchema"));
 
-                let validator_schema = schema_bson_option.map(|schema_bson| from_bson::<ValidatorSchema>(schema_bson.clone()).ok())??;
-                Some(make_collection_schema(name, &validator_schema))
+                match schema_bson_option {
+                    Some(schema_bson) => {
+                        from_bson::<ValidatorSchema>(schema_bson.clone()).map_err(|err| {
+                            MongoAgentError::BadCollectionSchema(
+                                name.to_owned(),
+                                schema_bson.clone(),
+                                err,
+                            )
+                        })
+                    }
+                    None => Ok(ValidatorSchema {
+                        bson_type: BsonType::Object,
+                        description: None,
+                        required: Vec::new(),
+                        properties: IndexMap::new(),
+                    }),
+                }
+                .map(|validator_schema| make_collection_schema(name, &validator_schema))
             },
         )
-        .collect::<Vec<WithName<Schema>>>()
+        .try_collect::<Vec<WithName<Schema>>>()
         .await?;
 
     Ok(WithName::into_map(schemas))

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,8 +10,8 @@ use mongodb_agent_common::interface_types::MongoConfig;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
-    #[arg(long = "sample-size", value_name = "N")]
-    sample_size: Option<u32>,
+    #[arg(long = "sample-size", value_name = "N", default_value = "10")]
+    sample_size: u32,
 }
 
 /// The command invoked by the user.
@@ -36,19 +36,18 @@ pub async fn run(command: Command, context: &Context) -> anyhow::Result<()> {
 
 /// Update the configuration in the current directory by introspecting the database.
 async fn update(context: &Context, args: &UpdateArgs) -> anyhow::Result<()> {
-    let schemas = match args.sample_size {
-        None => introspection::get_metadata_from_validation_schema(&context.mongo_config).await?,
-        Some(sample_size) => {
-            let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
+    let schemas_from_json_validation = introspection::get_metadata_from_validation_schema(&context.mongo_config).await?;
+    configuration::write_schema_directory(&context.path, schemas_from_json_validation).await?;
+
+    let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
+    let schemas_from_sampling = 
             introspection::sample_schema_from_db(
-                sample_size,
+                args.sample_size,
                 &context.mongo_config,
                 &existing_schemas,
             )
-            .await?
-        }
-    };
-    configuration::write_schema_directory(&context.path, schemas).await?;
+            .await?;
+    configuration::write_schema_directory(&context.path, schemas_from_sampling).await?;
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
-use configuration::Configuration;
 use mongodb_agent_common::interface_types::MongoConfig;
 
 #[derive(Debug, Clone, Parser)]
@@ -37,15 +36,13 @@ pub async fn run(command: Command, context: &Context) -> anyhow::Result<()> {
 
 /// Update the configuration in the current directory by introspecting the database.
 async fn update(context: &Context, args: &UpdateArgs) -> anyhow::Result<()> {
-    let schema = match args.sample_size {
+    let schemas = match args.sample_size {
         None => introspection::get_metadata_from_validation_schema(&context.mongo_config).await?,
         Some(sample_size) => {
             introspection::sample_schema_from_db(sample_size, &context.mongo_config).await?
         }
     };
-    let configuration = Configuration::from_schema(schema)?;
-
-    configuration::write_directory(&context.path, &configuration).await?;
+    configuration::write_schema_directory(&context.path, schemas).await?;
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,8 +10,8 @@ use mongodb_agent_common::interface_types::MongoConfig;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
-    #[arg(long = "sample-size", value_name = "N", default_value = "10")]
-    sample_size: u32,
+    #[arg(long = "sample-size", value_name = "N")]
+    sample_size: Option<u32>,
 }
 
 /// The command invoked by the user.
@@ -36,18 +36,19 @@ pub async fn run(command: Command, context: &Context) -> anyhow::Result<()> {
 
 /// Update the configuration in the current directory by introspecting the database.
 async fn update(context: &Context, args: &UpdateArgs) -> anyhow::Result<()> {
-    let schemas_from_json_validation = introspection::get_metadata_from_validation_schema(&context.mongo_config).await?;
-    configuration::write_schema_directory(&context.path, schemas_from_json_validation).await?;
-
-    let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
-    let schemas_from_sampling = 
+    let schemas = match args.sample_size {
+        None => introspection::get_metadata_from_validation_schema(&context.mongo_config).await?,
+        Some(sample_size) => {
+            let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
             introspection::sample_schema_from_db(
-                args.sample_size,
+                sample_size,
                 &context.mongo_config,
                 &existing_schemas,
             )
-            .await?;
-    configuration::write_schema_directory(&context.path, schemas_from_sampling).await?;
+            .await?
+        }
+    };
+    configuration::write_schema_directory(&context.path, schemas).await?;
 
     Ok(())
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -39,7 +39,13 @@ async fn update(context: &Context, args: &UpdateArgs) -> anyhow::Result<()> {
     let schemas = match args.sample_size {
         None => introspection::get_metadata_from_validation_schema(&context.mongo_config).await?,
         Some(sample_size) => {
-            introspection::sample_schema_from_db(sample_size, &context.mongo_config).await?
+            let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
+            introspection::sample_schema_from_db(
+                sample_size,
+                &context.mongo_config,
+                &existing_schemas,
+            )
+            .await?
         }
     };
     configuration::write_schema_directory(&context.path, schemas).await?;

--- a/crates/configuration/src/directory.rs
+++ b/crates/configuration/src/directory.rs
@@ -144,14 +144,6 @@ pub async fn write_schema_directory(
     write_subdir_configs(&subdir, schemas).await
 }
 
-// /// Currently only writes `schema.json`
-// pub async fn write_directory(
-//     configuration_dir: impl AsRef<Path>,
-//     configuration: &Configuration,
-// ) -> anyhow::Result<()> {
-//     write_file(configuration_dir, SCHEMA_FILENAME, &configuration.schema).await
-// }
-
 fn default_file_path(configuration_dir: impl AsRef<Path>, basename: &str) -> PathBuf {
     let dir = configuration_dir.as_ref();
     dir.join(format!("{basename}.{DEFAULT_EXTENSION}"))

--- a/crates/configuration/src/directory.rs
+++ b/crates/configuration/src/directory.rs
@@ -144,6 +144,14 @@ pub async fn write_schema_directory(
     write_subdir_configs(&subdir, schemas).await
 }
 
+// /// Currently only writes `schema.json`
+// pub async fn write_directory(
+//     configuration_dir: impl AsRef<Path>,
+//     configuration: &Configuration,
+// ) -> anyhow::Result<()> {
+//     write_file(configuration_dir, SCHEMA_FILENAME, &configuration.schema).await
+// }
+
 fn default_file_path(configuration_dir: impl AsRef<Path>, basename: &str) -> PathBuf {
     let dir = configuration_dir.as_ref();
     dir.join(format!("{basename}.{DEFAULT_EXTENSION}"))

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -5,6 +5,7 @@ pub mod schema;
 mod with_name;
 
 pub use crate::configuration::Configuration;
+pub use crate::directory::list_existing_schemas;
 pub use crate::directory::read_directory;
 pub use crate::directory::write_schema_directory;
 pub use crate::schema::Schema;

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -6,6 +6,6 @@ mod with_name;
 
 pub use crate::configuration::Configuration;
 pub use crate::directory::read_directory;
-pub use crate::directory::write_directory;
+pub use crate::directory::write_schema_directory;
 pub use crate::schema::Schema;
 pub use crate::with_name::{WithName, WithNameRef};

--- a/crates/configuration/src/schema/mod.rs
+++ b/crates/configuration/src/schema/mod.rs
@@ -42,4 +42,23 @@ impl Schema {
             .iter()
             .map(|(name, field)| WithNameRef::named(name, field))
     }
+
+    /// Unify two schemas. Assumes that the schemas describe mutually exclusive sets of collections.
+    pub fn merge(schema_a: Schema, schema_b: Schema) -> Schema {
+        let collections = schema_a
+            .collections
+            .into_iter()
+            .chain(schema_b.collections)
+            .collect();
+        let object_types = schema_a
+            .object_types
+            .into_iter()
+            .chain(schema_b.object_types)
+            .collect();
+        Schema {
+            collections,
+            object_types,
+        }
+    }
+
 }


### PR DESCRIPTION
## Describe your changes

Schema files will now be created and read from a subdirectory `schema/` containing one schema file per collection.
If a collection already has a schema then the `update` command skip sampling from the database for that schema.

## Issue ticket number and link

https://hasurahq.atlassian.net/browse/MDB-83
