### PR TITLE
Add "sensible" default behaviour for the CLI `update` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 - Use separate schema files for each collection
 - Don't sample from collections that already have a schema
+- New default behaviour for `update` CLI command: for each collection
+  - attempt to use validator schema if available
+  - if no validator schema, sample documents
+  - default sample size is 10
 
 ## [0.0.2] - 2024-03-26
 - Rename CLI plugin to ndc-mongodb ([PR #13](https://github.com/hasura/ndc-mongodb/pull/13))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ This changelog documents the changes between release versions.
 
 ## [Unreleased]
 - Use separate schema files for each collection
-- Don't sample from collections that already have a schema
-- New default behaviour for `update` CLI command: for each collection
-  - attempt to use validator schema if available
-  - if no validator schema, sample documents
-  - default sample size is 10
+- Changes to `update` CLI command:
+  - new default behaviour:
+    - attempt to use validator schema if available
+    - if no validator schema then sample documents from the collection
+  - don't sample from collections that already have a schema
+  - if no --sample-size given on command line, default sample size is 10
+  - new option --no-validator-schema to disable attempting to use validator schema
 
 ## [0.0.2] - 2024-03-26
 - Rename CLI plugin to ndc-mongodb ([PR #13](https://github.com/hasura/ndc-mongodb/pull/13))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 This changelog documents the changes between release versions.
 
 ## [Unreleased]
-- Use separate schema files for each collection
-- Changes to `update` CLI command:
+- Use separate schema files for each collection ([PR #14](https://github.com/hasura/ndc-mongodb/pull/14))
+- Changes to `update` CLI command ([PR #17](https://github.com/hasura/ndc-mongodb/pull/17)):
   - new default behaviour:
     - attempt to use validator schema if available
     - if no validator schema then sample documents from the collection

--- a/crates/cli/src/introspection/validation_schema.rs
+++ b/crates/cli/src/introspection/validation_schema.rs
@@ -31,20 +31,13 @@ pub async fn get_metadata_from_validation_schema(
             .as_ref()
             .and_then(|x| x.get("$jsonSchema"));
 
-        match schema_bson_option {
-            Some(schema_bson) => {
-                let validator_schema =
-                    from_bson::<ValidatorSchema>(schema_bson.clone()).map_err(|err| {
-                        MongoAgentError::BadCollectionSchema(
-                            name.to_owned(),
-                            schema_bson.clone(),
-                            err,
-                        )
-                    })?;
-                let collection_schema = make_collection_schema(name, &validator_schema);
-                schemas.push(collection_schema);
-            }
-            None => {}
+        if let Some(schema_bson) = schema_bson_option {
+            let validator_schema =
+                from_bson::<ValidatorSchema>(schema_bson.clone()).map_err(|err| {
+                    MongoAgentError::BadCollectionSchema(name.to_owned(), schema_bson.clone(), err)
+                })?;
+            let collection_schema = make_collection_schema(name, &validator_schema);
+            schemas.push(collection_schema);
         }
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -10,8 +10,8 @@ use mongodb_agent_common::interface_types::MongoConfig;
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateArgs {
-    #[arg(long = "sample-size", value_name = "N")]
-    sample_size: Option<u32>,
+    #[arg(long = "sample-size", value_name = "N", default_value = "10")]
+    sample_size: u32,
 }
 
 /// The command invoked by the user.
@@ -36,19 +36,16 @@ pub async fn run(command: Command, context: &Context) -> anyhow::Result<()> {
 
 /// Update the configuration in the current directory by introspecting the database.
 async fn update(context: &Context, args: &UpdateArgs) -> anyhow::Result<()> {
-    let schemas = match args.sample_size {
-        None => introspection::get_metadata_from_validation_schema(&context.mongo_config).await?,
-        Some(sample_size) => {
-            let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
-            introspection::sample_schema_from_db(
-                sample_size,
-                &context.mongo_config,
-                &existing_schemas,
-            )
-            .await?
-        }
-    };
-    configuration::write_schema_directory(&context.path, schemas).await?;
+    let schemas_from_json_validation =
+        introspection::get_metadata_from_validation_schema(&context.mongo_config).await?;
+    configuration::write_schema_directory(&context.path, schemas_from_json_validation).await?;
 
-    Ok(())
+    let existing_schemas = configuration::list_existing_schemas(&context.path).await?;
+    let schemas_from_sampling = introspection::sample_schema_from_db(
+        args.sample_size,
+        &context.mongo_config,
+        &existing_schemas,
+    )
+    .await?;
+    configuration::write_schema_directory(&context.path, schemas_from_sampling).await
 }


### PR DESCRIPTION
## Describe your changes

Attempt to provide some "sensible" default behaviour for the `update` command if no command line parameters are given.
The idea is to have something that will work well for most users when run from `ddn quickstart` or `ddn dev`.

- Default behaviour is now to use the validator schema if a collection has one.
- If there is no validator schema then sample documents from the collection instead.
- If no `--sample-size` is given on the command line then default to a sample size of 10.
- Add new command line flag `--no-validator-schema` which overrides the default behaviour and prevents the command from attempting to use validator schemas.

## Issue ticket number and link

[MDB-83](https://hasurahq.atlassian.net/browse/MDB-83)


[MDB-83]: https://hasurahq.atlassian.net/browse/MDB-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ