### PR TITLE
capture error results from connector handlers in traces

### DIFF
--- a/crates/mongodb-connector/src/mongo_connector.rs
+++ b/crates/mongodb-connector/src/mongo_connector.rs
@@ -18,6 +18,7 @@ use ndc_sdk::{
         QueryResponse, SchemaResponse,
     },
 };
+use tracing::instrument;
 
 use crate::{
     api_type_conversions::{
@@ -36,6 +37,7 @@ impl Connector for MongoConnector {
     type Configuration = Configuration;
     type State = MongoConfig;
 
+    #[instrument(err, skip_all)]
     async fn parse_configuration(
         configuration_dir: impl AsRef<Path> + Send,
     ) -> Result<Self::Configuration, ParseError> {
@@ -46,6 +48,10 @@ impl Connector for MongoConnector {
     }
 
     /// Reads database connection URI from environment variable
+    #[instrument(err, skip_all)]
+    // `instrument` automatically emits traces when this function returns.
+    // - `err` limits logging to `Err` results, at log level `error`
+    // - `skip_all` omits arguments from the trace
     async fn try_init_state(
         configuration: &Self::Configuration,
         _metrics: &mut prometheus::Registry,
@@ -54,6 +60,7 @@ impl Connector for MongoConnector {
         Ok(state)
     }
 
+    #[instrument(err, skip_all)]
     fn fetch_metrics(
         _configuration: &Self::Configuration,
         _state: &Self::State,
@@ -61,6 +68,7 @@ impl Connector for MongoConnector {
         Ok(())
     }
 
+    #[instrument(err, skip_all)]
     async fn health_check(
         _configuration: &Self::Configuration,
         state: &Self::State,
@@ -78,6 +86,7 @@ impl Connector for MongoConnector {
         mongo_capabilities_response().into()
     }
 
+    #[instrument(err, skip_all)]
     async fn get_schema(
         configuration: &Self::Configuration,
     ) -> Result<JsonResponse<SchemaResponse>, SchemaError> {
@@ -85,6 +94,7 @@ impl Connector for MongoConnector {
         Ok(response.into())
     }
 
+    #[instrument(err, skip_all)]
     async fn query_explain(
         _configuration: &Self::Configuration,
         state: &Self::State,
@@ -103,6 +113,7 @@ impl Connector for MongoConnector {
         Ok(v2_to_v3_explain_response(response).into())
     }
 
+    #[instrument(err, skip_all)]
     async fn mutation_explain(
         _configuration: &Self::Configuration,
         _state: &Self::State,
@@ -113,6 +124,7 @@ impl Connector for MongoConnector {
         ))
     }
 
+    #[instrument(err, skip_all)]
     async fn mutation(
         _configuration: &Self::Configuration,
         state: &Self::State,
@@ -121,6 +133,7 @@ impl Connector for MongoConnector {
         handle_mutation_request(state, request).await
     }
 
+    #[instrument(err, skip_all)]
     async fn query(
         _configuration: &Self::Configuration,
         state: &Self::State,


### PR DESCRIPTION
Capture error results in traces. This should probably be done in the SDK - but it probably wouldn't hurt to instrument in both places. This gets errors exported via opentelemetry, and logs to stdout.

Ticket: https://hasurahq.atlassian.net/browse/MDB-97