### PR TITLE
Rename Type::Any to Type::ExtendedJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This changelog documents the changes between release versions.
 - Queries that attempt to compare a column to a column in the query root table, or a related table, will now fail instead of giving the incorrect result ([#22](https://github.com/hasura/ndc-mongodb/pull/22))
 - Fix bug in v2 to v3 conversion of query responses containing nested objects ([PR #27](https://github.com/hasura/ndc-mongodb/pull/27))
 - Fixed bug where use of aggregate functions in queries would fail ([#26](https://github.com/hasura/ndc-mongodb/pull/26))
+- Rename Any type to ExtendedJSON to make its representation clearer ([#30](https://github.com/hasura/ndc-mongodb/pull/30))
 
 ## [0.0.3] - 2024-03-28
 - Use separate schema files for each collection ([PR #14](https://github.com/hasura/ndc-mongodb/pull/14))

--- a/crates/cli/src/introspection/sampling.rs
+++ b/crates/cli/src/introspection/sampling.rs
@@ -123,10 +123,7 @@ pub fn type_from_bson(
     (WithName::into_map(object_types), t)
 }
 
-fn make_field_type(
-    object_type_name: &str,
-    field_value: &Bson,
-) -> (Vec<ObjectType>, Type) {
+fn make_field_type(object_type_name: &str, field_value: &Bson) -> (Vec<ObjectType>, Type) {
     fn scalar(t: BsonScalarType) -> (Vec<ObjectType>, Type) {
         (vec![], Type::Scalar(t))
     }
@@ -138,8 +135,7 @@ fn make_field_type(
             let mut collected_otds = vec![];
             let mut result_type = Type::Scalar(Undefined);
             for elem in arr {
-                let (elem_collected_otds, elem_type) =
-                    make_field_type(object_type_name, elem);
+                let (elem_collected_otds, elem_type) = make_field_type(object_type_name, elem);
                 collected_otds = if collected_otds.is_empty() {
                     elem_collected_otds
                 } else {
@@ -301,7 +297,7 @@ mod tests {
                         (
                             "bar".to_owned(),
                             ObjectField {
-                                r#type: Type::Any,
+                                r#type: Type::ExtendedJSON,
                                 description: None,
                             },
                         ),

--- a/crates/mongodb-agent-common/src/query/serialization/bson_to_json.rs
+++ b/crates/mongodb-agent-common/src/query/serialization/bson_to_json.rs
@@ -42,7 +42,7 @@ type Result<T> = std::result::Result<T, BsonToJsonError>;
 /// The BSON library already has a `Serialize` impl that can convert to JSON. But that
 /// implementation emits Extended JSON which includes inline type tags in JSON output to
 /// disambiguate types on the BSON side. We don't want those tags because we communicate type
-/// information out of band. That is except for the `Type::Any` type where we do want to emit
+/// information out of band. That is except for the `Type::ExtendedJSON` type where we do want to emit
 /// Extended JSON because we don't have out-of-band information in that case.
 pub fn bson_to_json(
     expected_type: &Type,
@@ -50,7 +50,7 @@ pub fn bson_to_json(
     value: Bson,
 ) -> Result<Value> {
     match expected_type {
-        Type::Any => Ok(value.into_canonical_extjson()),
+        Type::ExtendedJSON => Ok(value.into_canonical_extjson()),
         Type::Scalar(scalar_type) => bson_scalar_to_json(*scalar_type, value),
         Type::Object(object_type_name) => {
             let object_type = object_types

--- a/crates/mongodb-agent-common/src/query/serialization/json_to_bson.rs
+++ b/crates/mongodb-agent-common/src/query/serialization/json_to_bson.rs
@@ -61,7 +61,9 @@ pub fn json_to_bson(
     value: Value,
 ) -> Result<Bson> {
     match expected_type {
-        Type::Any => serde_json::from_value::<Bson>(value).map_err(JsonToBsonError::SerdeError),
+        Type::ExtendedJSON => {
+            serde_json::from_value::<Bson>(value).map_err(JsonToBsonError::SerdeError)
+        }
         Type::Scalar(t) => json_to_bson_scalar(*t, value),
         Type::Object(object_type_name) => {
             let object_type = object_types

--- a/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
+++ b/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
@@ -14,7 +14,10 @@ pub fn scalar_types_capabilities() -> HashMap<String, ScalarTypeCapabilities> {
     let mut map = all::<BsonScalarType>()
         .map(|t| (t.graphql_name(), capabilities(t)))
         .collect::<HashMap<_, _>>();
-    map.insert(mongodb_support::ANY_TYPE_NAME.to_owned(), ScalarTypeCapabilities::new());
+    map.insert(
+        mongodb_support::EXTENDED_JSON_TYPE_NAME.to_owned(),
+        ScalarTypeCapabilities::new(),
+    );
     map
 }
 

--- a/crates/mongodb-connector/src/schema.rs
+++ b/crates/mongodb-connector/src/schema.rs
@@ -65,10 +65,10 @@ fn map_field_infos(
 fn map_type(t: &schema::Type) -> models::Type {
     fn map_normalized_type(t: &schema::Type) -> models::Type {
         match t {
-            // Any can respresent any BSON value, including null, so it is always nullable
-            schema::Type::Any => models::Type::Nullable {
+            // ExtendedJSON can respresent any BSON value, including null, so it is always nullable
+            schema::Type::ExtendedJSON => models::Type::Nullable {
                 underlying_type: Box::new(models::Type::Named {
-                    name: mongodb_support::ANY_TYPE_NAME.to_owned(),
+                    name: mongodb_support::EXTENDED_JSON_TYPE_NAME.to_owned(),
                 }),
             },
             schema::Type::Scalar(t) => models::Type::Named {

--- a/crates/mongodb-support/src/lib.rs
+++ b/crates/mongodb-support/src/lib.rs
@@ -1,7 +1,7 @@
+pub mod align;
 mod bson_type;
 pub mod error;
-pub mod align;
 
 pub use self::bson_type::{BsonScalarType, BsonType};
 
-pub const ANY_TYPE_NAME: &str = "any";
+pub const EXTENDED_JSON_TYPE_NAME: &str = "ExtendedJSON";


### PR DESCRIPTION
## Describe your changes

Rename the `Any` type to `ExtendedJSON`. This makes it clearer to the user how values of this type are represented.

## Issue ticket number and link

[MDB-105](https://hasurahq.atlassian.net/browse/MDB-105)

[MDB-105]: https://hasurahq.atlassian.net/browse/MDB-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ