### PR TITLE
Fix collection schemas not having a unique constraint for the `_id` column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog documents the changes between release versions.
 - Fix bug in v2 to v3 conversion of query responses containing nested objects ([PR #27](https://github.com/hasura/ndc-mongodb/pull/27))
 - Fixed bug where use of aggregate functions in queries would fail ([#26](https://github.com/hasura/ndc-mongodb/pull/26))
 - Rename Any type to ExtendedJSON to make its representation clearer ([#30](https://github.com/hasura/ndc-mongodb/pull/30))
+- The collection primary key `_id` property now has a unique constraint generated in the NDC schema for it ([#32](https://github.com/hasura/ndc-mongodb/pull/32))
 
 ## [0.0.3] - 2024-03-28
 - Use separate schema files for each collection ([PR #14](https://github.com/hasura/ndc-mongodb/pull/14))

--- a/fixtures/connector/chinook/schema/Album.json
+++ b/fixtures/connector/chinook/schema/Album.json
@@ -25,9 +25,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Artist.json
+++ b/fixtures/connector/chinook/schema/Artist.json
@@ -22,9 +22,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Customer.json
+++ b/fixtures/connector/chinook/schema/Customer.json
@@ -93,9 +93,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+             "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Employee.json
+++ b/fixtures/connector/chinook/schema/Employee.json
@@ -109,9 +109,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+             "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Genre.json
+++ b/fixtures/connector/chinook/schema/Genre.json
@@ -22,9 +22,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Invoice.json
+++ b/fixtures/connector/chinook/schema/Invoice.json
@@ -65,9 +65,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/InvoiceLine.json
+++ b/fixtures/connector/chinook/schema/InvoiceLine.json
@@ -35,9 +35,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/MediaType.json
+++ b/fixtures/connector/chinook/schema/MediaType.json
@@ -22,9 +22,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Playlist.json
+++ b/fixtures/connector/chinook/schema/Playlist.json
@@ -22,9 +22,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/PlaylistTrack.json
+++ b/fixtures/connector/chinook/schema/PlaylistTrack.json
@@ -20,9 +20,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },

--- a/fixtures/connector/chinook/schema/Track.json
+++ b/fixtures/connector/chinook/schema/Track.json
@@ -63,9 +63,7 @@
         },
         "_id": {
           "type": {
-            "nullable": {
-              "scalar": "objectId"
-            }
+            "scalar": "objectId"
           }
         }
       },


### PR DESCRIPTION
The schema endpoint was not listing a unique constraint for collections that captured the `_id` column that every Mongo table must have that is the primary key of the table.

It now generates a unique constraint named `<collection name>_id` for that column, so long as the table's object type indicates the presence of an `_id` column of type object id. That should always be the case, but if it's missing for some (bad) reason, we just omit the unique constraint too.

The test configuration in `fixtures/connector/chinook` has been updated to fix the `_id` columns being nullable, which they aren't. `_id` must always have a value.