### PR TITLE
validate changelog in CI checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,15 @@ jobs:
       - name: run unit tests 🔨
         run: nix build .#checks.x86_64-linux.test --print-build-logs
 
-      - name: run linter checks with clippy 🔨
+      - name: run linter checks with clippy 📎
         run: nix build .#checks.x86_64-linux.lint --print-build-logs
 
-      - name: audit for reported security problems 🔨
+      - name: audit for reported security problems 🛡️
         run: nix build .#checks.x86_64-linux.audit --print-build-logs
+
+      - name: validate changelog 📜
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_level: error
+          version: Unreleased
+          path: ./CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,4 +25,4 @@ This changelog documents the changes between release versions.
 - Rename CLI plugin to ndc-mongodb ([PR #13](https://github.com/hasura/ndc-mongodb/pull/13))
 
 ## [0.0.1] - 2024-03-22
-Initial release
+- Initial release


### PR DESCRIPTION
## Describe your changes

We're using [changelog-reader-action](https://github.com/mindsers/changelog-reader-action) to generate release changelogs. That action assumes the changelog is in a format described by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This PR adds a CI check to verify the changelog is in that format.