### PR TITLE
move v3-e2e-testing fetcher out of flake

### DIFF
--- a/arion-compose/service-e2e-testing.nix
+++ b/arion-compose/service-e2e-testing.nix
@@ -4,10 +4,19 @@
 }:
 
 let
+  v3-e2e-testing-source = builtins.fetchGit {
+    url = "git+ssh://git@github.com/hasura/v3-e2e-testing?ref=jesse/update-mongodb";
+    name = "v3-e2e-testing-source";
+    ref = "jesse/update-mongodb";
+    rev = "325240c938c253a21f2fe54161b0c94e54f1a3a5";
+  };
+
+  v3-e2e-testing = pkgs.pkgsCross.linux.callPackage ../nix/v3-e2e-testing.nix { src = v3-e2e-testing-source; database-to-test = "mongodb"; };
+
   e2e-testing-service = {
     useHostStore = true;
     command = [
-      "${pkgs.pkgsCross.linux.v3-e2e-testing}/bin/v3-e2e-testing-mongodb"
+      "${v3-e2e-testing}/bin/v3-e2e-testing-mongodb"
     ];
     environment = pkgs.lib.optionalAttrs (engine-graphql-url != null) {
       ENGINE_GRAPHQL_URL = engine-graphql-url;

--- a/flake.lock
+++ b/flake.lock
@@ -231,8 +231,7 @@
         "graphql-engine-source": "graphql-engine-source",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
-        "systems": "systems_2",
-        "v3-e2e-testing-source": "v3-e2e-testing-source"
+        "systems": "systems_2"
       }
     },
     "rust-overlay": {
@@ -284,23 +283,6 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
-      }
-    },
-    "v3-e2e-testing-source": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1706578034,
-        "narHash": "sha256-DkbumGH6W51qs4pHpEE972pUfyUiGfZFFNitv8p6DaQ=",
-        "ref": "jesse/update-mongodb",
-        "rev": "325240c938c253a21f2fe54161b0c94e54f1a3a5",
-        "revCount": 161,
-        "type": "git",
-        "url": "ssh://git@github.com/hasura/v3-e2e-testing"
-      },
-      "original": {
-        "ref": "jesse/update-mongodb",
-        "type": "git",
-        "url": "ssh://git@github.com/hasura/v3-e2e-testing"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -52,13 +52,6 @@
       url = "github:hasura/graphql-engine/50f1243a46e22f0fecca03364b0b181fbb3735c6";
       flake = false;
     };
-
-    # See the note above on graphql-engine-source for information on running
-    # against a version of v3-e2e-testing with local changes.
-    v3-e2e-testing-source = {
-      url = "git+ssh://git@github.com/hasura/v3-e2e-testing?ref=jesse/update-mongodb";
-      flake = false;
-    };
   };
 
   outputs =
@@ -70,7 +63,6 @@
     , arion
     , graphql-engine-source
     , dev-auth-webhook-source
-    , v3-e2e-testing-source
     , systems
     , ...
     }:
@@ -100,8 +92,6 @@
           mongodb-connector = final.mongodb-connector-workspace.override { package = "mongodb-connector"; }; # override `package` to build one specific crate
           mongodb-cli-plugin = final.mongodb-connector-workspace.override { package = "mongodb-cli-plugin"; };
           graphql-engine = final.callPackage ./nix/graphql-engine.nix { src = "${graphql-engine-source}/v3"; package = "engine"; };
-          v3-e2e-testing = final.callPackage ./nix/v3-e2e-testing.nix { src = v3-e2e-testing-source; database-to-test = "mongodb"; };
-          inherit v3-e2e-testing-source; # include this source so we can read files from it in arion-compose configs
           dev-auth-webhook = final.callPackage ./nix/dev-auth-webhook.nix { src = "${dev-auth-webhook-source}/v3/crates/hasura-authn-webhook/dev-auth-webhook"; };
 
           # Provide cross-compiled versions of each of our packages under


### PR DESCRIPTION
## Describe your changes

Removes the `v3-e2e-testing` input from `flake.nix`, and moves it to a fetcher in the arion configuration that runs the e2e service. The e2e repo is private - if we keep it in the flake the entire nix setup will be broken for anyone who isn't set up to access the e2e repo with ssh authentication. Moving the fetcher to that specific arion config file prevents an authentication error unless you're specifically running e2e tests.

The advantage of having inputs in `flake.nix` is that we can update versions with commands like `nix flake update`, and nix handles locking versions automatically. OTOH with `builtins.fetchGit` we have to edit the file to set the git revision that we want.