### PR TITLE
Add collection name as an option for native queries

### DIFF
--- a/crates/configuration/src/native_query.rs
+++ b/crates/configuration/src/native_query.rs
@@ -15,6 +15,7 @@ use crate::{schema::ObjectField, serialized};
 #[derive(Clone, Debug)]
 pub struct NativeQuery {
     pub representation: NativeQueryRepresentation,
+    pub collection_name: Option<String>,
     pub arguments: BTreeMap<String, ObjectField>,
     pub result_document_type: String,
     pub pipeline: Vec<bson::Document>,
@@ -25,6 +26,7 @@ impl From<serialized::NativeQuery> for NativeQuery {
     fn from(value: serialized::NativeQuery) -> Self {
         NativeQuery {
             representation: value.representation,
+            collection_name: value.collection_name,
             arguments: value.arguments,
             result_document_type: value.result_document_type,
             pipeline: value.pipeline,

--- a/crates/configuration/src/native_query.rs
+++ b/crates/configuration/src/native_query.rs
@@ -15,7 +15,7 @@ use crate::{schema::ObjectField, serialized};
 #[derive(Clone, Debug)]
 pub struct NativeQuery {
     pub representation: NativeQueryRepresentation,
-    pub collection_name: Option<String>,
+    pub input_collection: Option<String>,
     pub arguments: BTreeMap<String, ObjectField>,
     pub result_document_type: String,
     pub pipeline: Vec<bson::Document>,
@@ -26,7 +26,7 @@ impl From<serialized::NativeQuery> for NativeQuery {
     fn from(value: serialized::NativeQuery) -> Self {
         NativeQuery {
             representation: value.representation,
-            collection_name: value.collection_name,
+            input_collection: value.input_collection,
             arguments: value.arguments,
             result_document_type: value.result_document_type,
             pipeline: value.pipeline,

--- a/crates/configuration/src/serialized/native_query.rs
+++ b/crates/configuration/src/serialized/native_query.rs
@@ -33,9 +33,9 @@ pub struct NativeQuery {
     /// a "function" in your ddn configuration.
     pub representation: NativeQueryRepresentation,
 
-    /// When using a `representation` of `collection` you can set the `collection_name` if you want
+    /// When using a `representation` of `collection` you can set the `input_collection` if you want
     /// the aggregation pipeline to start off of your collection.
-    pub collection_name: Option<String>,
+    pub input_collection: Option<String>,
 
     /// Arguments to be supplied for each query invocation. These will be available to the given
     /// pipeline as variables. For information about variables in MongoDB aggregation expressions

--- a/crates/configuration/src/serialized/native_query.rs
+++ b/crates/configuration/src/serialized/native_query.rs
@@ -33,6 +33,10 @@ pub struct NativeQuery {
     /// a "function" in your ddn configuration.
     pub representation: NativeQueryRepresentation,
 
+    /// When using a `representation` of `collection` you can set the `collection_name` if you want
+    /// the aggregation pipeline to start off of your collection.
+    pub collection_name: Option<String>,
+
     /// Arguments to be supplied for each query invocation. These will be available to the given
     /// pipeline as variables. For information about variables in MongoDB aggregation expressions
     /// see https://www.mongodb.com/docs/manual/reference/aggregation-variables/

--- a/crates/configuration/src/serialized/native_query.rs
+++ b/crates/configuration/src/serialized/native_query.rs
@@ -33,8 +33,8 @@ pub struct NativeQuery {
     /// a "function" in your ddn configuration.
     pub representation: NativeQueryRepresentation,
 
-    /// When using a `representation` of `collection` you can set the `input_collection` if you want
-    /// the aggregation pipeline to start off of your collection.
+    /// Use `input_collection` when you want to start an aggregation pipeline off of the specified
+    /// `input_collection` db.<input_collection>.aggregate.
     pub input_collection: Option<String>,
 
     /// Arguments to be supplied for each query invocation. These will be available to the given

--- a/crates/mongodb-agent-common/src/explain.rs
+++ b/crates/mongodb-agent-common/src/explain.rs
@@ -22,9 +22,14 @@ pub async fn explain_query(
 
     let aggregate_target = match QueryTarget::for_request(config, &query_request) {
         QueryTarget::Collection(collection_name) => Bson::String(collection_name),
-        // 1 means aggregation without a collection target - as in `db.aggregate()` instead of
-        // `db.<collection>.aggregate()`
-        QueryTarget::NativeQuery { .. } => Bson::Int32(1),
+        QueryTarget::NativeQuery { native_query, .. } => {
+            match &native_query.input_collection {
+                Some(collection_name) => Bson::String(collection_name.to_string()),
+                // 1 means aggregation without a collection target - as in `db.aggregate()` instead of
+                // `db.<collection>.aggregate()`
+                None => Bson::Int32(1)
+            }
+        }
     };
 
     let query_command = doc! {

--- a/crates/mongodb-agent-common/src/query/execute_query_request.rs
+++ b/crates/mongodb-agent-common/src/query/execute_query_request.rs
@@ -39,8 +39,14 @@ pub async fn execute_query_request(
             let collection = database.collection(&collection_name);
             collect_from_cursor(collection.aggregate(pipeline, None).await?).await
         }
-        QueryTarget::NativeQuery { .. } => {
-            collect_from_cursor(database.aggregate(pipeline, None).await?).await
+        QueryTarget::NativeQuery { native_query, .. } => {
+            match native_query.clone().collection_name {
+                Some(coll_name) => {
+                    let collection = database.collection(&coll_name.to_string());
+                    collect_from_cursor(collection.aggregate(pipeline, None).await?).await
+                },
+                None => collect_from_cursor(database.aggregate(pipeline, None).await?).await
+            }
         }
     }?;
 

--- a/crates/mongodb-agent-common/src/query/execute_query_request.rs
+++ b/crates/mongodb-agent-common/src/query/execute_query_request.rs
@@ -40,9 +40,9 @@ pub async fn execute_query_request(
             collect_from_cursor(collection.aggregate(pipeline, None).await?).await
         }
         QueryTarget::NativeQuery { native_query, .. } => {
-            match native_query.clone().collection_name {
-                Some(coll_name) => {
-                    let collection = database.collection(&coll_name.to_string());
+            match &native_query.input_collection {
+                Some(collection_name) => {
+                    let collection = database.collection(collection_name);
                     collect_from_cursor(collection.aggregate(pipeline, None).await?).await
                 },
                 None => collect_from_cursor(database.aggregate(pipeline, None).await?).await

--- a/crates/mongodb-agent-common/src/query/native_query.rs
+++ b/crates/mongodb-agent-common/src/query/native_query.rs
@@ -101,6 +101,7 @@ mod tests {
     async fn executes_native_query() -> Result<(), anyhow::Error> {
         let native_query = NativeQuery {
             representation: NativeQueryRepresentation::Collection,
+            collection_name: None,
             arguments: [
                 (
                     "filter".to_string(),

--- a/crates/mongodb-agent-common/src/query/native_query.rs
+++ b/crates/mongodb-agent-common/src/query/native_query.rs
@@ -101,7 +101,7 @@ mod tests {
     async fn executes_native_query() -> Result<(), anyhow::Error> {
         let native_query = NativeQuery {
             representation: NativeQueryRepresentation::Collection,
-            collection_name: None,
+            input_collection: None,
             arguments: [
                 (
                     "filter".to_string(),


### PR DESCRIPTION
## Describe your changes
Add optional `collection_name` to native query configuration. When a `collection_name` is used in configuration the pipeline is run using that collection as the base.

### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [x] enhancement
- [ ] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->

### Changelog entry
<!--
  - Add a user understandable changelog entry
  - Include all details needed to understand the change. Try including links to docs or issues if relevant
  - For Highlights start with a H4 heading (#### <entry title>)
  - Get the changelog entry reviewed by your team
-->

Add optional `collection_name` to native query configuration. When a `collection_name` is used in configuration the pipeline is run using that collection as the base.

<!-- changelog-entry : end : DO NOT REMOVE -->

<!-- changelog : end : DO NOT REMOVE -->
