### PR TITLE
run integration tests against multiple mongodb versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: nix build .#checks.x86_64-linux.audit --print-build-logs
 
       - name: run integration tests 📋
-        run: nix develop --command just test-integration
+        run: nix develop --command just test-mongodb-versions

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Requirements
 
-* Rust `>= 1.57`
-* MongoDB `>= 3.6`
+* Rust via Rustup
+* MongoDB `>= 4`
 * OpenSSL development files
 
-or Nix
+or get dependencies automatically with Nix
 
 Some of the build instructions require Nix. To set that up [install Nix][], and
 configure it to [enable flakes][].
@@ -106,6 +106,18 @@ or `.sh` scripts added to this directory will be run when the mongodb service is
 run from a fresh state. Note that you will have to remove any existing docker
 volume to get to a fresh state. Using arion you can remove volumes by running
 `arion down`.
+
+### Running with a different MongoDB version
+
+Override the MongoDB version that arion runs by assigning a Docker image name to
+the environment variable `MONGODB_IMAGE`. For example,
+
+    $ arion down --volumes # delete potentially-incompatible MongoDB data
+    $ MONGODB_IMAGE=mongo:4 arion up -d
+
+Or run integration tests against a specific MongoDB version,
+
+    $ MONGODB_IMAGE=mongo:4 just test-integration
 
 ## License
 

--- a/arion-compose/services/mongodb.nix
+++ b/arion-compose/services/mongodb.nix
@@ -1,7 +1,7 @@
 # Provides an arion-compose service. Use in arion-compose.nix like this:
 #
 #     services = {
-#       mongodb = import ./arion-compose/mongodb-service.nix {
+#       mongodb = import ./arion-compose/services/mongodb.nix {
 #         inherit pkgs;
 #         port = "27017"; 
 #       };
@@ -10,24 +10,32 @@
 { pkgs
 , port ? "27017"
 , hostPort ? null
-, environment ? {}
+, mongodb-image ? "mongo:7"
+, environment ? { }
 , volumes ? [
     # By default load fixtures in the mongo-connector repo
-    (import ../fixtures/mongodb.nix).chinook
+    (import ../fixtures/mongodb.nix).allFixtures
   ]
 }:
 
 let
   MONGO_INITDB_DATABASE = "test";
+
+  image-from-env = builtins.getEnv "MONGODB_IMAGE";
+  image = if image-from-env != "" then image-from-env else mongodb-image;
+
+  # Prior to v6 MongoDB provides an older client shell called "mongo". The new
+  # shell in v6 and later is called "mongosh"
+  mongosh = if builtins.lessThan major-version 6 then "mongo" else "mongosh";
+  major-version = pkgs.lib.toInt (builtins.head (builtins.match ".*:([0-9]).*" image));
 in
 {
   service = {
-    image = "mongo:6-jammy";
+    inherit image volumes;
     environment = { inherit MONGO_INITDB_DATABASE; } // environment;
-    inherit volumes;
     ports = pkgs.lib.optionals (hostPort != null) [ "${hostPort}:${port}" ];
     healthcheck = {
-      test = [ "CMD-SHELL" ''echo 'db.runCommand("ping").ok' | mongosh localhost:27017/${MONGO_INITDB_DATABASE} --quiet'' ];
+      test = [ "CMD-SHELL" ''echo 'db.runCommand("ping").ok' | ${mongosh} localhost:${port}/${MONGO_INITDB_DATABASE} --quiet'' ];
       interval = "5s";
       timeout = "10s";
       retries = 5;

--- a/fixtures/mongodb/chinook/chinook-import.sh
+++ b/fixtures/mongodb/chinook/chinook-import.sh
@@ -6,6 +6,13 @@ set -euo pipefail
 FIXTURES=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 DATABASE_NAME=chinook
 
+# In v6 and later the bundled MongoDB client shell is called "mongosh". In
+# earlier versions it's called "mongo".
+MONGO_SH=mongosh
+if ! command -v mongosh &> /dev/null; then
+  MONGO_SH=mongo
+fi
+
 echo "📡 Importing Chinook into database $DATABASE_NAME..."
 
 importCollection() {
@@ -13,7 +20,7 @@ importCollection() {
   local schema_file="$FIXTURES/$collection.schema.json"
   local data_file="$FIXTURES/$collection.data.json"
   echo "🔐 Applying validation for ${collection}..."
-    mongosh --eval "
+    $MONGO_SH --eval "
         var schema = $(cat "${schema_file}");
         db.createCollection('${collection}', { validator: schema });
     " "$DATABASE_NAME"

--- a/fixtures/mongodb/sample_import.sh
+++ b/fixtures/mongodb/sample_import.sh
@@ -8,14 +8,21 @@ set -euo pipefail
 # Get the directory of this script file
 FIXTURES=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# In v6 and later the bundled MongoDB client shell is called "mongosh". In
+# earlier versions it's called "mongo".
+MONGO_SH=mongosh
+if ! command -v mongosh &> /dev/null; then
+  MONGO_SH=mongo
+fi
+
 # Sample Claims Data
 echo "📡 Importing claims sample data..."
 mongoimport --db sample_claims --collection companies --type csv --headerline --file "$FIXTURES"/sample_claims/companies.csv
 mongoimport --db sample_claims --collection carriers --type csv --headerline --file "$FIXTURES"/sample_claims/carriers.csv
 mongoimport --db sample_claims --collection account_groups --type csv --headerline --file "$FIXTURES"/sample_claims/account_groups.csv
 mongoimport --db sample_claims --collection claims --type csv --headerline --file "$FIXTURES"/sample_claims/claims.csv
-mongosh sample_claims "$FIXTURES"/sample_claims/view_flat.js
-mongosh sample_claims "$FIXTURES"/sample_claims/view_nested.js
+$MONGO_SH sample_claims "$FIXTURES"/sample_claims/view_flat.js
+$MONGO_SH sample_claims "$FIXTURES"/sample_claims/view_nested.js
 echo "✅ Sample claims data imported..."
 
 # mongo_flix

--- a/justfile
+++ b/justfile
@@ -15,6 +15,13 @@ test-ndc: (_arion "arion-compose/ndc-test.nix" "test")
 
 test-e2e: (_arion "arion-compose/e2e-testing.nix" "test")
 
+# Run `just test-integration` on several MongoDB versions
+test-mongodb-versions:
+  MONGODB_IMAGE=mongo:4 just test-integration
+  # MONGODB_IMAGE=mongo:5 just test-integration # there's a problem with the native query example in v5
+  MONGODB_IMAGE=mongo:6 just test-integration
+  MONGODB_IMAGE=mongo:7 just test-integration
+
 # Runs a specified service in a specified project config using arion (a nix
 # frontend for docker-compose). Propagates the exit status from that service.
 _arion project service:


### PR DESCRIPTION
## Describe your changes

Runs integration tests against MongoDB versions 4, 6, and 7. (The oldest version supported by MongoDB is 4.4. The most recent stable release is 7.0) Version 5 is skipped for now because there is a problem with the `hello` native query example in that version.

We can't claim to support v3.6 because the `$replaceWith` stage wasn't implemented in that version.