### PR TITLE
Mention MONGODB_DATABASE_URI environment variable in error message if it is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog documents the changes between release versions.
 ## [Unreleased]
 - Fix incorrect order of results for query requests with more than 10 variable sets (#37)
 - In the CLI update command, don't overwrite schema files that haven't changed ([#49](https://github.com/hasura/ndc-mongodb/pull/49/files))
+- In the CLI update command, if the database URI is not provided the error message now mentions the correct environment variable to use (`MONGODB_DATABASE_URI`) ([#50](https://github.com/hasura/ndc-mongodb/pull/50))
 
 ## [0.0.4] - 2024-04-12
 - Queries that attempt to compare a column to a column in the query root table, or a related table, will now fail instead of giving the incorrect result ([#22](https://github.com/hasura/ndc-mongodb/pull/22))


### PR DESCRIPTION
## Describe your changes

If the database URI is missing we want the error message to mention the environment variable `MONGODB_DATABASE_URI` instead of the command line option `--connection-uri`.
When run via the `ddn` CLI, the environment variable will be the primary means of specifying this option and it is confusing not to mention it.

## Issue ticket number and link

[MDB-119](https://hasurahq.atlassian.net/browse/MDB-119)

### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [x] enhancement
- [ ] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->


[MDB-119]: https://hasurahq.atlassian.net/browse/MDB-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ