### PR TITLE
enable integration tests for mongo 5 skipping problem test in that version

### DIFF
--- a/arion-compose/services/integration-tests.nix
+++ b/arion-compose/services/integration-tests.nix
@@ -14,6 +14,7 @@ let
     environment = {
       ENGINE_GRAPHQL_URL = engine-graphql-url;
       INSTA_WORKSPACE_ROOT = repo-source-mount-point;
+      MONGODB_IMAGE = builtins.getEnv "MONGODB_IMAGE";
     };
     volumes = [
       "${builtins.getEnv "PWD"}:${repo-source-mount-point}:rw"

--- a/crates/integration-tests/src/tests/native_query.rs
+++ b/crates/integration-tests/src/tests/native_query.rs
@@ -3,6 +3,17 @@ use insta::assert_yaml_snapshot;
 
 #[tokio::test]
 async fn runs_native_query_with_function_representation() -> anyhow::Result<()> {
+    // Skip this test in MongoDB 5 because the example fails there. We're getting an error:
+    //
+    // > Kind: Command failed: Error code 5491300 (Location5491300): $documents' is not allowed in user requests, labels: {}
+    //
+    // This doesn't affect native queries that don't use the $documents stage.
+    if let Ok(image) = std::env::var("MONGODB_IMAGE") {
+        if image == "mongo:5" {
+            return Ok(());
+        }
+    }
+
     assert_yaml_snapshot!(
         query(
             r#"

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ test-e2e: (_arion "arion-compose/e2e-testing.nix" "test")
 
 # Run `just test-integration` on several MongoDB versions
 test-mongodb-versions:
-  # MONGODB_IMAGE=mongo:5 just test-integration # there's a problem with the native query example in v5
+  MONGODB_IMAGE=mongo:5 just test-integration
   MONGODB_IMAGE=mongo:6 just test-integration
   MONGODB_IMAGE=mongo:7 just test-integration
 


### PR DESCRIPTION
## Describe your changes

Enables integration tests for MongoDB 5. Skips the one test that is failing in that version. It's a problem with the example native query, not with the connector.