### PR TITLE
use concise correlated subquery syntax for relations with single column mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This changelog documents the changes between release versions.
 
 ## [Unreleased]
+- Relations with a single column mapping now use concise correlated subquery syntax in `$lookup` stage ([#65](https://github.com/hasura/ndc-mongodb/pull/65))
 
 ## [0.0.5] - 2024-04-26
 - Fix incorrect order of results for query requests with more than 10 variable sets (#37)


### PR DESCRIPTION
## Describe your changes

This generates a simpler query plan when there is only one column mapping. Previously a `$lookup` looked like this:

```json
{
    "$lookup": {
        "from": "students",
        "let": {
            "v__id": "$_id"
        },
        "pipeline": [
            {
                "$match": { "$expr": {
                    "$eq": ["$$v__id", "$classId"]
                } }
            },
            {
                "$replaceWith": {
                    "student_name": { "$ifNull": ["$name", null] },
                },
            }
        ],
        "as": "students",
    },
},
```

After the change it looks like this:

```json
{
    "$lookup": {
        "from": "students",
        "localField": "_id",
        "foreignField": "classId",
        "pipeline": [
            {
                "$replaceWith": {
                    "student_name": { "$ifNull": ["$name", null] },
                },
            }
        ],
        "as": "students",
    },
},
```

I think this will give better query performance due to avoiding the use of a variable in an expression. I need to do some more research to confirm that.

Cases with multiple column mappings still use the first form. I'm going to check to see if we can avoid a variable in those cases too.

## Issue ticket number and link

[MDB-125](https://hasurahq.atlassian.net/browse/MDB-125)

[MDB-125]: https://hasurahq.atlassian.net/browse/MDB-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ