### PR TITLE
skip empty collections when building schemas via database introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog documents the changes between release versions.
 - Support for root collection column references ([#75](https://github.com/hasura/ndc-mongodb/pull/75))
 - Fix for databases with field names that begin with a dollar sign, or that contain dots ([#74](https://github.com/hasura/ndc-mongodb/pull/74))
 - Implement column-to-column comparisons within the same collection ([#74](https://github.com/hasura/ndc-mongodb/pull/74))
+- Fix error tracking collection with no documents by skipping such collections during CLI introspection ([#76](https://github.com/hasura/ndc-mongodb/pull/76))
 
 ## [0.0.6] - 2024-05-01
 - Enables logging events from the MongoDB driver by setting the `RUST_LOG` variable ([#67](https://github.com/hasura/ndc-mongodb/pull/67))

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,6 +1,7 @@
 //! The interpretation of the commands that the CLI can handle.
 
 mod introspection;
+mod logging;
 
 use std::path::PathBuf;
 

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -1,0 +1,7 @@
+#[macro_export]
+macro_rules! log_warning {
+    ($msg:literal) => {
+        eprint!("warning: ");
+        eprintln!($msg);
+    };
+}


### PR DESCRIPTION
If we record an empty schema we get an error tracking models. If a collection is empty there is nothing to sample, and therefore we end up with an empty schema. This change skips empty collections, and prints a warning instead of recording empty schemas.

There is some extra whitespace churn in `sampling.rs` because I ran rustfmt

[MDB-162](https://hasurahq.atlassian.net/browse/MDB-162)

[MDB-162]: https://hasurahq.atlassian.net/browse/MDB-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ