### PR TITLE
unify compatible numeric types in cli introspection

### DIFF
--- a/crates/cli/src/introspection/type_unification.rs
+++ b/crates/cli/src/introspection/type_unification.rs
@@ -8,7 +8,10 @@ use configuration::{
 };
 use indexmap::IndexMap;
 use itertools::Itertools as _;
-use mongodb_support::{align::align, BsonScalarType::*};
+use mongodb_support::{
+    align::align,
+    BsonScalarType::{self, *},
+};
 use std::string::String;
 
 type ObjectField = WithName<schema::ObjectField>;
@@ -43,11 +46,13 @@ pub fn unify_type(type_a: Type, type_b: Type) -> Type {
         (Type::Scalar(Null), type_b) => type_b.make_nullable(),
         (type_a, Type::Scalar(Null)) => type_a.make_nullable(),
 
-        // Scalar types unify if they are the same type.
+        // Scalar types unify if they are the same type, or if one is a superset of the other.
         // If they are diffferent then the union is ExtendedJSON.
         (Type::Scalar(scalar_a), Type::Scalar(scalar_b)) => {
-            if scalar_a == scalar_b {
+            if scalar_a == scalar_b || is_supertype(&scalar_a, &scalar_b) {
                 Type::Scalar(scalar_a)
+            } else if is_supertype(&scalar_b, &scalar_a) {
+                Type::Scalar(scalar_b)
             } else {
                 Type::ExtendedJSON
             }
@@ -167,6 +172,13 @@ pub fn unify_object_types(
     );
 
     merged_type_map.into_values().collect()
+}
+
+fn is_supertype(a: &BsonScalarType, b: &BsonScalarType) -> bool {
+    matches!(
+        (a, b),
+        (Double, Int) | (Long, Int) | (Decimal, Int) | (Decimal, Double) | (Decimal, Long)
+    )
 }
 
 #[cfg(test)]
@@ -305,6 +317,36 @@ mod tests {
             let fields: HashSet<String> = result.value.fields.into_keys().collect();
             assert!(left.into_keys().chain(right.into_keys()).chain(shared.into_keys()).all(|k| fields.contains(&k)),
                 "Missing field in result type")
+        }
+    }
+
+    #[test]
+    fn test_double_and_int_unify_as_double() {
+        let double = || Type::Scalar(BsonScalarType::Double);
+        let int = || Type::Scalar(BsonScalarType::Int);
+
+        let u = unify_type(double(), int());
+        assert_eq!(u, double());
+
+        let u = unify_type(int(), double());
+        assert_eq!(u, double());
+    }
+
+    #[test]
+    fn test_nullable_double_and_int_unify_as_nullable_double() {
+        let double = || Type::Scalar(BsonScalarType::Double);
+        let int = || Type::Scalar(BsonScalarType::Int);
+
+        for (a, b) in [
+            (double().make_nullable(), int()),
+            (double(), int().make_nullable()),
+            (double().make_nullable(), int().make_nullable()),
+            (int(), double().make_nullable()),
+            (int().make_nullable(), double()),
+            (int().make_nullable(), double().make_nullable()),
+        ] {
+            let u = unify_type(a, b);
+            assert_eq!(u, double().make_nullable());
         }
     }
 }


### PR DESCRIPTION
Previously if we saw a mixture of numeric types in the same field in different documents in a collection we would infer the `ExtendedJSON` type for that field. This PR changes that behavior to infer one of the numeric types in use if it is capable of representing all of the possible values of the other numeric types without loss of precision. For example if a field includes both `double` and `int` values then the inferred type for that field is `double`.