### PR TITLE
Relax type requirements for primary uniqueness constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog documents the changes between release versions.
 - Support for root collection column references ([#75](https://github.com/hasura/ndc-mongodb/pull/75))
 - Fix for databases with field names that begin with a dollar sign, or that contain dots ([#74](https://github.com/hasura/ndc-mongodb/pull/74))
 - Implement column-to-column comparisons within the same collection ([#74](https://github.com/hasura/ndc-mongodb/pull/74))
+- Don't require _id field to have type ObjectId when generating primary uniqueness constraint ([#79](https://github.com/hasura/ndc-mongodb/pull/79))
 
 ## [0.0.6] - 2024-05-01
 - Enables logging events from the MongoDB driver by setting the `RUST_LOG` variable ([#67](https://github.com/hasura/ndc-mongodb/pull/67))

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -285,7 +285,11 @@ fn get_primary_key_uniqueness_constraint(
     // Check to make sure our collection's object type contains the _id field
     // If it doesn't (should never happen, all collections need an _id column), don't generate the constraint
     let object_type = object_types.get(collection_type)?;
-    let _id_field = object_type.fields.get("_id")?;
+    let id_field = object_type.fields.get("_id")?;
+    match &id_field.r#type {
+        schema::Type::Scalar(scalar_type) if scalar_type.is_comparable() => Some(()),
+        _ => None,
+    }?;
     let uniqueness_constraint = ndc::UniquenessConstraint {
         unique_columns: vec!["_id".into()],
     };

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -282,14 +282,10 @@ fn get_primary_key_uniqueness_constraint(
     name: &str,
     collection_type: &str,
 ) -> Option<(String, ndc::UniquenessConstraint)> {
-    // Check to make sure our collection's object type contains the _id objectid field
+    // Check to make sure our collection's object type contains the _id field
     // If it doesn't (should never happen, all collections need an _id column), don't generate the constraint
     let object_type = object_types.get(collection_type)?;
-    let id_field = object_type.fields.get("_id")?;
-    match &id_field.r#type {
-        schema::Type::Scalar(BsonScalarType::ObjectId) => Some(()),
-        _ => None,
-    }?;
+    let _id_field = object_type.fields.get("_id")?;
     let uniqueness_constraint = ndc::UniquenessConstraint {
         unique_columns: vec!["_id".into()],
     };

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -2,7 +2,6 @@ use std::{collections::BTreeMap, path::Path};
 
 use anyhow::{anyhow, ensure};
 use itertools::Itertools;
-use mongodb_support::BsonScalarType;
 use ndc_models as ndc;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Don't require _id field to have type ObjectId when generate primary uniqueness constraint

### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [ ] enhancement
- [x] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->
