### PR TITLE
fix bson serialization test for case where double and int unify to double

### DIFF
--- a/crates/cli/src/introspection/type_unification.rs
+++ b/crates/cli/src/introspection/type_unification.rs
@@ -174,6 +174,16 @@ pub fn unify_object_types(
     merged_type_map.into_values().collect()
 }
 
+/// True iff we consider a to be a supertype of b.
+///
+/// Note that if you add more supertypes here then it is important to also update the custom
+/// equality check in our tests in mongodb_agent_common::query::serialization::tests. Equality
+/// needs to be transitive over supertypes, so for example if we have,
+///
+/// (Double, Int), (Decimal, Double)
+///
+/// then in addition to comparing ints to doubles, and doubles to decimals, we also need to compare
+/// decimals to ints.
 fn is_supertype(a: &BsonScalarType, b: &BsonScalarType) -> bool {
     matches!((a, b), (Double, Int))
 }

--- a/crates/mongodb-agent-common/proptest-regressions/query/serialization/tests.txt
+++ b/crates/mongodb-agent-common/proptest-regressions/query/serialization/tests.txt
@@ -8,3 +8,4 @@ cc 2efdea7f185f2f38ae643782b3523014ab7b8236e36a79cc6b7a7cac74b06f79 # shrinks to
 cc 26e2543468ab6d4ffa34f9f8a2c920801ef38a35337557a8f4e74c92cf57e344 # shrinks to bson = Document({" ": Document({"¡": DateTime(1970-01-01 0:00:00.001 +00:00:00)})})
 cc 7d760e540b56fedac7dd58e5bdb5bb9613b9b0bc6a88acfab3fc9c2de8bf026d # shrinks to bson = Document({"A": Array([Null, Undefined])})
 cc 21360610045c5a616b371fb8d5492eb0c22065d62e54d9c8a8761872e2e192f3 # shrinks to bson = Array([Document({}), Document({" ": Null})])
+cc 8842e7f78af24e19847be5d8ee3d47c547ef6c1bb54801d360a131f41a87f4fa


### PR DESCRIPTION
In #77 I neglected to adjust our round-trip bson-to-json serialization proptest to handle cases where we treat ints as interchangeable with doubles. This change adds a custom equality test for use solely in tests that can compare ints and doubles.