### PR TITLE
Use field type in comparison target instead of column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog documents the changes between release versions.
 
 ## [Unreleased]
 
+- Fix bug with operator lookup when filtering on nested fields ([#82](https://github.com/hasura/ndc-mongodb/pull/82))
+
 ## [0.1.0] - 2024-06-13
 
 - Support filtering and sorting by fields of related collections ([#72](https://github.com/hasura/ndc-mongodb/pull/72))

--- a/crates/mongodb-agent-common/src/query/column_ref.rs
+++ b/crates/mongodb-agent-common/src/query/column_ref.rs
@@ -163,7 +163,7 @@ mod tests {
         let target = ComparisonTarget::Column {
             name: "imdb".into(),
             field_path: Some(vec!["rating".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::Double)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::Double)),
             path: Default::default(),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -177,7 +177,7 @@ mod tests {
         let target = ComparisonTarget::Column {
             name: "subtitles".into(),
             field_path: Some(vec!["english.us".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             path: Default::default(),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -199,7 +199,7 @@ mod tests {
         let target = ComparisonTarget::Column {
             name: "meta.subtitles".into(),
             field_path: Some(vec!["english_us".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             path: Default::default(),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -221,7 +221,7 @@ mod tests {
         let target = ComparisonTarget::Column {
             name: "meta".into(),
             field_path: Some(vec!["$unsafe".into(), "$also_unsafe".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             path: Default::default(),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -248,7 +248,7 @@ mod tests {
         let target = ComparisonTarget::Column {
             name: "valid_key".into(),
             field_path: Some(vec!["also_valid".into(), "$not_valid".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             path: Default::default(),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -270,7 +270,7 @@ mod tests {
         let target = ComparisonTarget::ColumnInScope {
             name: "field".into(),
             field_path: Some(vec!["prop1".into(), "prop2".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             scope: Scope::Root,
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -284,7 +284,7 @@ mod tests {
         let target = ComparisonTarget::ColumnInScope {
             name: "$field".into(),
             field_path: Default::default(),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             scope: Scope::Named("scope_0".into()),
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -306,7 +306,7 @@ mod tests {
         let target = ComparisonTarget::ColumnInScope {
             name: "field".into(),
             field_path: Some(vec!["$unsafe_name".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             scope: Scope::Root,
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -329,7 +329,7 @@ mod tests {
         let target = ComparisonTarget::ColumnInScope {
             name: "$field".into(),
             field_path: Some(vec!["$unsafe_name1".into(), "$unsafe_name2".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             scope: Scope::Root,
         };
         let actual = ColumnRef::from_comparison_target(&target);
@@ -361,7 +361,7 @@ mod tests {
         let target = ComparisonTarget::ColumnInScope {
             name: "field".into(),
             field_path: Some(vec!["prop1".into(), "$unsafe_name".into()]),
-            column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+            field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
             scope: Scope::Root,
         };
         let actual = ColumnRef::from_comparison_target(&target);

--- a/crates/mongodb-agent-common/src/query/make_selector.rs
+++ b/crates/mongodb-agent-common/src/query/make_selector.rs
@@ -200,7 +200,7 @@ mod tests {
                 column: ComparisonTarget::Column {
                     name: "Name".to_owned(),
                     field_path: None,
-                    column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+                    field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
                     path: vec!["Albums".into(), "Tracks".into()],
                 },
                 operator: ComparisonFunction::Equal,
@@ -236,7 +236,7 @@ mod tests {
                 column: ComparisonTarget::Column {
                     name: "Name".to_owned(),
                     field_path: None,
-                    column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+                    field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
                     path: vec!["Albums".into(), "Tracks".into()],
                 },
                 operator: UnaryComparisonOperator::IsNull,
@@ -267,7 +267,7 @@ mod tests {
                 column: ComparisonTarget::Column {
                     name: "Name".to_owned(),
                     field_path: None,
-                    column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+                    field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
                     path: Default::default(),
                 },
                 operator: ComparisonFunction::Equal,
@@ -275,7 +275,7 @@ mod tests {
                     column: ComparisonTarget::Column {
                         name: "Title".to_owned(),
                         field_path: None,
-                        column_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
+                        field_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::String)),
                         path: Default::default(),
                     },
                 },

--- a/crates/ndc-query-plan/src/plan_for_query_request/helpers.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/helpers.rs
@@ -21,6 +21,53 @@ pub fn find_object_field<'a, S>(
     })
 }
 
+pub fn find_object_field_path<'a, S>(
+    object_type: &'a plan::ObjectType<S>,
+    field_name: &str,
+    field_path: &Option<Vec<String>>,
+) -> Result<&'a plan::Type<S>> {
+    match field_path {
+        None => find_object_field(object_type, field_name),
+        Some(field_path) => find_object_field_path_helper(object_type, field_name, field_path),
+    }
+}
+
+fn find_object_field_path_helper<'a, S>(
+    object_type: &'a plan::ObjectType<S>,
+    field_name: &str,
+    field_path: &[String],
+) -> Result<&'a plan::Type<S>> {
+    let field_type = find_object_field(object_type, field_name)?;
+    match field_path {
+        [] => Ok(field_type),
+        [nested_field_name, rest @ ..] => {
+            let o = find_object_type(field_type, &object_type.name, field_name)?;
+            find_object_field_path_helper(o, nested_field_name, rest)
+        }
+    }
+}
+
+fn find_object_type<'a, S>(
+    t: &'a plan::Type<S>,
+    parent_type: &Option<String>,
+    field_name: &str,
+) -> Result<&'a plan::ObjectType<S>> {
+    match t {
+        crate::Type::Scalar(_) => Err(QueryPlanError::ExpectedObjectTypeAtField {
+            parent_type: parent_type.to_owned(),
+            field_name: field_name.to_owned(),
+            got: "scalar".to_owned(),
+        }),
+        crate::Type::ArrayOf(_) => Err(QueryPlanError::ExpectedObjectTypeAtField {
+            parent_type: parent_type.to_owned(),
+            field_name: field_name.to_owned(),
+            got: "array".to_owned(),
+        }),
+        crate::Type::Nullable(t) => find_object_type(t, parent_type, field_name),
+        crate::Type::Object(object_type) => Ok(object_type),
+    }
+}
+
 pub fn lookup_relationship<'a>(
     relationships: &'a BTreeMap<String, ndc::Relationship>,
     relationship: &str,

--- a/crates/ndc-query-plan/src/plan_for_query_request/query_plan_error.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/query_plan_error.rs
@@ -59,6 +59,13 @@ pub enum QueryPlanError {
 
     #[error("Query referenced a relationship, \"{0}\", but did not include relation metadata in `collection_relationships`")]
     UnspecifiedRelation(String),
+
+    #[error("Expected field {field_name} of object {} to be an object type. Got {got}.", parent_type.to_owned().unwrap_or("".to_owned()))]
+    ExpectedObjectTypeAtField {
+        parent_type: Option<String>,
+        field_name: String,
+        got: String,
+    },
 }
 
 fn at_path(path: &[String]) -> String {

--- a/crates/ndc-query-plan/src/plan_for_query_request/tests.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/tests.rs
@@ -129,7 +129,7 @@ fn translates_query_request_relationships() -> Result<(), anyhow::Error> {
                                 column: plan::ComparisonTarget::Column {
                                     name: "_id".into(),
                                     field_path: None,
-                                    column_type: plan::Type::Scalar(
+                                    field_type: plan::Type::Scalar(
                                         plan_test_helpers::ScalarType::Int,
                                     ),
                                     path: vec!["class_department".into()],
@@ -139,7 +139,7 @@ fn translates_query_request_relationships() -> Result<(), anyhow::Error> {
                                     column: plan::ComparisonTarget::Column {
                                         name: "math_department_id".into(),
                                         field_path: None,
-                                        column_type: plan::Type::Scalar(
+                                        field_type: plan::Type::Scalar(
                                             plan_test_helpers::ScalarType::Int,
                                         ),
                                         path: vec!["school_directory".into()],
@@ -394,7 +394,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                             column: plan::ComparisonTarget::Column {
                                 name: "author_id".into(),
                                 field_path: Default::default(),
-                                column_type: plan::Type::Scalar(plan_test_helpers::ScalarType::Int),
+                                field_type: plan::Type::Scalar(plan_test_helpers::ScalarType::Int),
                                 path: Default::default(),
                             },
                             operator: plan_test_helpers::ComparisonOperator::Equal,
@@ -402,7 +402,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                                 column: plan::ComparisonTarget::ColumnInScope {
                                     name: "id".into(),
                                     field_path: Default::default(),
-                                    column_type: plan::Type::Scalar(
+                                    field_type: plan::Type::Scalar(
                                         plan_test_helpers::ScalarType::Int,
                                     ),
                                     scope: plan::Scope::Root,
@@ -413,7 +413,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                             column: plan::ComparisonTarget::Column {
                                 name: "title".into(),
                                 field_path: Default::default(),
-                                column_type: plan::Type::Scalar(
+                                field_type: plan::Type::Scalar(
                                     plan_test_helpers::ScalarType::String,
                                 ),
                                 path: Default::default(),
@@ -454,7 +454,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                             plan::Expression::BinaryComparisonOperator {
                                 column: plan::ComparisonTarget::Column {
                                     name: "author_id".into(),
-                                    column_type: plan::Type::Scalar(
+                                    field_type: plan::Type::Scalar(
                                         plan_test_helpers::ScalarType::Int,
                                     ),
                                     field_path: None,
@@ -465,7 +465,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                                     column: plan::ComparisonTarget::ColumnInScope {
                                         name: "id".into(),
                                         scope: plan::Scope::Root,
-                                        column_type: plan::Type::Scalar(
+                                        field_type: plan::Type::Scalar(
                                             plan_test_helpers::ScalarType::Int,
                                         ),
                                         field_path: None,
@@ -475,7 +475,7 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                             plan::Expression::BinaryComparisonOperator {
                                 column: plan::ComparisonTarget::Column {
                                     name: "title".into(),
-                                    column_type: plan::Type::Scalar(
+                                    field_type: plan::Type::Scalar(
                                         plan_test_helpers::ScalarType::String,
                                     ),
                                     field_path: None,
@@ -609,7 +609,7 @@ fn translates_relationships_in_fields_predicates_and_orderings() -> Result<(), a
                     column: plan::ComparisonTarget::Column {
                         name: "title".into(),
                         field_path: Default::default(),
-                        column_type: plan::Type::Scalar(plan_test_helpers::ScalarType::String),
+                        field_type: plan::Type::Scalar(plan_test_helpers::ScalarType::String),
                         path: Default::default(),
                     },
                     operator: plan_test_helpers::ComparisonOperator::Regex,
@@ -873,7 +873,7 @@ fn translates_predicate_referencing_field_of_related_collection() -> anyhow::Res
                     column: plan::ComparisonTarget::Column {
                         name: "name".into(),
                         field_path: None,
-                        column_type: plan::Type::Scalar(plan_test_helpers::ScalarType::String),
+                        field_type: plan::Type::Scalar(plan_test_helpers::ScalarType::String),
                         path: vec!["author".into()],
                     },
                     operator: ndc_models::UnaryComparisonOperator::IsNull,

--- a/crates/ndc-query-plan/src/query_plan.rs
+++ b/crates/ndc-query-plan/src/query_plan.rs
@@ -303,7 +303,7 @@ pub enum ComparisonTarget<T: ConnectorTypes> {
         /// Path to a nested field within an object column
         field_path: Option<Vec<String>>,
 
-        column_type: Type<T::ScalarType>,
+        field_type: Type<T::ScalarType>,
 
         /// Any relationships to traverse to reach this column. These are translated from
         /// [ndc_models::PathElement] values in the [ndc_models::QueryRequest] to names of relation
@@ -321,7 +321,7 @@ pub enum ComparisonTarget<T: ConnectorTypes> {
         /// Path to a nested field within an object column
         field_path: Option<Vec<String>>,
 
-        column_type: Type<T::ScalarType>,
+        field_type: Type<T::ScalarType>,
     },
 }
 
@@ -342,10 +342,10 @@ impl<T: ConnectorTypes> ComparisonTarget<T> {
 }
 
 impl<T: ConnectorTypes> ComparisonTarget<T> {
-    pub fn get_column_type(&self) -> &Type<T::ScalarType> {
+    pub fn get_field_type(&self) -> &Type<T::ScalarType> {
         match self {
-            ComparisonTarget::Column { column_type, .. } => column_type,
-            ComparisonTarget::ColumnInScope { column_type, .. } => column_type,
+            ComparisonTarget::Column { field_type, .. } => field_type,
+            ComparisonTarget::ColumnInScope { field_type, .. } => field_type,
         }
     }
 }


### PR DESCRIPTION
## Describe your changes

Fixes a bug where comparison operator lookup for nested field comparisons was using the column type rather than the type of the nested field, resulting in an `UnknownComparisonOperator` error.

Note: we will need to do the same thing for ordering and aggregates eventually.

## Issue ticket number and link

[MDB-53](https://hasurahq.atlassian.net/browse/MDB-53)

### Type
_(Select only one. In case of multiple, choose the most appropriate)_
- [ ] highlight
- [ ] enhancement
- [x] bugfix
- [ ] behaviour-change
- [ ] performance-enhancement
- [ ] security-fix
<!-- type : end : DO NOT REMOVE -->


[MDB-53]: https://hasurahq.atlassian.net/browse/MDB-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ