### PR TITLE
add config option for relaxed or canonical extended json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This changelog documents the changes between release versions.
 - Rework query plans for requests with variable sets to allow use of indexes ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
 - Fix: error when requesting query plan if MongoDB is target of a remote join ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
 - Breaking change: remote joins no longer work in MongoDB v5 ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
+- Add configuration option to opt into "relaxed" mode for Extended JSON outputs
+  ([#84](https://github.com/hasura/ndc-mongodb/pull/84))
 
 ## [0.1.0] - 2024-06-13
 

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -2,6 +2,7 @@ use std::{collections::BTreeMap, path::Path};
 
 use anyhow::{anyhow, ensure};
 use itertools::Itertools;
+use mongodb_support::ExtendedJsonMode;
 use ndc_models as ndc;
 use serde::{Deserialize, Serialize};
 
@@ -231,14 +232,6 @@ pub struct ConfigurationSerializationOptions {
     /// used for output. This setting has no effect on inputs (query arguments, etc.).
     #[serde(default)]
     pub extended_json_mode: ExtendedJsonMode,
-}
-
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum ExtendedJsonMode {
-    #[default]
-    Canonical,
-    Relaxed,
 }
 
 fn merge_object_types<'a>(

--- a/crates/configuration/src/configuration.rs
+++ b/crates/configuration/src/configuration.rs
@@ -189,11 +189,16 @@ impl Configuration {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationOptions {
-    // Options for introspection
+    /// Options for introspection
     pub introspection_options: ConfigurationIntrospectionOptions,
+
+    /// Options that affect how BSON data from MongoDB is translated to JSON in GraphQL query
+    /// responses.
+    #[serde(default)]
+    pub serialization_options: ConfigurationSerializationOptions,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -217,6 +222,23 @@ impl Default for ConfigurationIntrospectionOptions {
             all_schema_nullable: true,
         }
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationSerializationOptions {
+    /// Extended JSON has two modes: canonical and relaxed. This option determines which mode is
+    /// used for output. This setting has no effect on inputs (query arguments, etc.).
+    #[serde(default)]
+    pub extended_json_mode: ExtendedJsonMode,
+}
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExtendedJsonMode {
+    #[default]
+    Canonical,
+    Relaxed,
 }
 
 fn merge_object_types<'a>(

--- a/crates/mongodb-agent-common/proptest-regressions/query/serialization/tests.txt
+++ b/crates/mongodb-agent-common/proptest-regressions/query/serialization/tests.txt
@@ -9,3 +9,4 @@ cc 26e2543468ab6d4ffa34f9f8a2c920801ef38a35337557a8f4e74c92cf57e344 # shrinks to
 cc 7d760e540b56fedac7dd58e5bdb5bb9613b9b0bc6a88acfab3fc9c2de8bf026d # shrinks to bson = Document({"A": Array([Null, Undefined])})
 cc 21360610045c5a616b371fb8d5492eb0c22065d62e54d9c8a8761872e2e192f3 # shrinks to bson = Array([Document({}), Document({" ": Null})])
 cc 8842e7f78af24e19847be5d8ee3d47c547ef6c1bb54801d360a131f41a87f4fa
+cc 2a192b415e5669716701331fe4141383a12ceda9acc9f32e4284cbc2ed6f2d8a # shrinks to bson = Document({"A": Document({"¡": JavaScriptCodeWithScope { code: "", scope: Document({"\0": Int32(-1)}) }})}), mode = Relaxed

--- a/crates/mongodb-agent-common/src/mongo_query_plan/mod.rs
+++ b/crates/mongodb-agent-common/src/mongo_query_plan/mod.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use configuration::{
     native_mutation::NativeMutation, native_query::NativeQuery, Configuration, MongoScalarType,
 };
-use mongodb_support::EXTENDED_JSON_TYPE_NAME;
+use mongodb_support::{ExtendedJsonMode, EXTENDED_JSON_TYPE_NAME};
 use ndc_models as ndc;
 use ndc_query_plan::{ConnectorTypes, QueryContext, QueryPlanError};
 
@@ -17,6 +17,10 @@ pub use ndc_query_plan::OrderByTarget;
 pub struct MongoConfiguration(pub Configuration);
 
 impl MongoConfiguration {
+    pub fn extended_json_mode(&self) -> ExtendedJsonMode {
+        self.0.options.serialization_options.extended_json_mode
+    }
+
     pub fn native_queries(&self) -> &BTreeMap<String, NativeQuery> {
         &self.0.native_queries
     }

--- a/crates/mongodb-agent-common/src/query/execute_query_request.rs
+++ b/crates/mongodb-agent-common/src/query/execute_query_request.rs
@@ -27,7 +27,7 @@ pub async fn execute_query_request(
     let query_plan = preprocess_query_request(config, query_request)?;
     let pipeline = pipeline_for_query_request(config, &query_plan)?;
     let documents = execute_query_pipeline(database, config, &query_plan, pipeline).await?;
-    let response = serialize_query_response(&query_plan, documents)?;
+    let response = serialize_query_response(config.extended_json_mode(), &query_plan, documents)?;
     Ok(response)
 }
 

--- a/crates/mongodb-agent-common/src/query/serialization/tests.rs
+++ b/crates/mongodb-agent-common/src/query/serialization/tests.rs
@@ -1,7 +1,7 @@
 use configuration::MongoScalarType;
 use mongodb::bson::Bson;
 use mongodb_cli_plugin::type_from_bson;
-use mongodb_support::BsonScalarType;
+use mongodb_support::{BsonScalarType, ExtendedJsonMode};
 use ndc_query_plan::{self as plan, inline_object_types};
 use plan::QueryContext;
 use proptest::prelude::*;
@@ -19,7 +19,9 @@ proptest! {
         let inferred_type = inline_object_types(&object_types, &inferred_schema_type.into(), MongoConfiguration::lookup_scalar_type)?;
         let error_context = |msg: &str, source: String| TestCaseError::fail(format!("{msg}: {source}\ninferred type: {inferred_type:?}\nobject types: {object_types:?}"));
 
-        let json = bson_to_json(&inferred_type, bson.clone()).map_err(|e| error_context("error converting bson to json", e.to_string()))?;
+        // Test using Canonical mode because Relaxed mode loses some information, and so does not
+        // round-trip precisely.
+        let json = bson_to_json(ExtendedJsonMode::Canonical, &inferred_type, bson.clone()).map_err(|e| error_context("error converting bson to json", e.to_string()))?;
         let actual = json_to_bson(&inferred_type, json.clone()).map_err(|e| error_context("error converting json to bson", e.to_string()))?;
         prop_assert!(custom_eq(&actual, &bson),
             "`(left == right)`\nleft: `{:?}`\nright: `{:?}`\ninferred type: {:?}\nobject types: {:?}\njson_representation: {}",
@@ -37,7 +39,7 @@ proptest! {
     fn converts_datetime_from_bson_to_json_and_back(d in arb_datetime()) {
         let t = plan::Type::Scalar(MongoScalarType::Bson(BsonScalarType::Date));
         let bson = Bson::DateTime(d);
-        let json = bson_to_json(&t, bson.clone())?;
+        let json = bson_to_json(ExtendedJsonMode::Canonical, &t, bson.clone())?;
         let actual = json_to_bson(&t, json.clone())?;
         prop_assert_eq!(actual, bson, "json representation: {}", json)
     }

--- a/crates/mongodb-connector/src/mutation.rs
+++ b/crates/mongodb-connector/src/mutation.rs
@@ -103,8 +103,12 @@ async fn execute_procedure(
         result_type
     };
 
-    let json_result = bson_to_json(&requested_result_type, rewritten_result)
-        .map_err(|err| MutationError::UnprocessableContent(err.to_string()))?;
+    let json_result = bson_to_json(
+        config.extended_json_mode(),
+        &requested_result_type,
+        rewritten_result,
+    )
+    .map_err(|err| MutationError::UnprocessableContent(err.to_string()))?;
 
     Ok(MutationOperationResults::Procedure {
         result: json_result,

--- a/crates/mongodb-support/src/extended_json_mode.rs
+++ b/crates/mongodb-support/src/extended_json_mode.rs
@@ -1,7 +1,8 @@
+use enum_iterator::Sequence;
 use mongodb::bson::Bson;
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Sequence, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum ExtendedJsonMode {
     #[default]

--- a/crates/mongodb-support/src/extended_json_mode.rs
+++ b/crates/mongodb-support/src/extended_json_mode.rs
@@ -1,0 +1,19 @@
+use mongodb::bson::Bson;
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ExtendedJsonMode {
+    #[default]
+    Canonical,
+    Relaxed,
+}
+
+impl ExtendedJsonMode {
+    pub fn into_extjson(self, value: Bson) -> serde_json::Value {
+        match self {
+            ExtendedJsonMode::Canonical => value.into_canonical_extjson(),
+            ExtendedJsonMode::Relaxed => value.into_relaxed_extjson(),
+        }
+    }
+}

--- a/crates/mongodb-support/src/lib.rs
+++ b/crates/mongodb-support/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod align;
 mod bson_type;
 pub mod error;
+mod extended_json_mode;
 
 pub use self::bson_type::{BsonScalarType, BsonType};
+pub use self::extended_json_mode::ExtendedJsonMode;
 
 pub const EXTENDED_JSON_TYPE_NAME: &str = "ExtendedJSON";

--- a/crates/test-helpers/src/lib.rs
+++ b/crates/test-helpers/src/lib.rs
@@ -2,6 +2,15 @@ pub mod arb_bson;
 mod arb_plan_type;
 pub mod arb_type;
 
+use enum_iterator::Sequence as _;
+use mongodb_support::ExtendedJsonMode;
+use proptest::prelude::*;
+
 pub use arb_bson::{arb_bson, arb_bson_with_options, ArbBsonOptions};
 pub use arb_plan_type::arb_plan_type;
 pub use arb_type::arb_type;
+
+pub fn arb_extended_json_mode() -> impl Strategy<Value = ExtendedJsonMode> {
+    (0..ExtendedJsonMode::CARDINALITY)
+        .prop_map(|n| enum_iterator::all::<ExtendedJsonMode>().nth(n).unwrap())
+}


### PR DESCRIPTION
Adds an option to allow users to opt into "relaxed" mode for Extended JSON output. Keeps "canonical" mode as the default because it is lossless. For example relaxed mode does not preserve the exact numeric type of each numeric value, while canonical mode does.

This does not affect inputs. For example sorts and filters will accept either canonical or relaxed input modes as before.

[MDB-169](https://hasurahq.atlassian.net/browse/MDB-169)

[MDB-169]: https://hasurahq.atlassian.net/browse/MDB-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ