### PR TITLE
fix: count aggregates return 0 instead of null if no rows match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog documents the changes between release versions.
 - Fix bug with operator lookup when filtering on nested fields ([#82](https://github.com/hasura/ndc-mongodb/pull/82))
 - Rework query plans for requests with variable sets to allow use of indexes ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
 - Fix: error when requesting query plan if MongoDB is target of a remote join ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
+- Fix: count aggregates return 0 instead of null if no rows match ([#85](https://github.com/hasura/ndc-mongodb/pull/85))
 - Breaking change: remote joins no longer work in MongoDB v5 ([#83](https://github.com/hasura/ndc-mongodb/pull/83))
 
 ## [0.1.0] - 2024-06-13

--- a/crates/mongodb-agent-common/src/aggregation_function.rs
+++ b/crates/mongodb-agent-common/src/aggregation_function.rs
@@ -31,4 +31,14 @@ impl AggregationFunction {
                 aggregate_function: s.to_owned(),
             })
     }
+
+    pub fn is_count(self) -> bool {
+        match self {
+            A::Avg => false,
+            A::Count => true,
+            A::Min => false,
+            A::Max => false,
+            A::Sum => false,
+        }
+    }
 }

--- a/crates/mongodb-agent-common/src/query/foreach.rs
+++ b/crates/mongodb-agent-common/src/query/foreach.rs
@@ -240,10 +240,17 @@ mod tests {
                         } },
                         { "$replaceWith": {
                             "aggregates": {
-                                "count": { "$getField": {
-                                    "field": "result",
-                                    "input": { "$first": { "$getField": { "$literal": "count" } } }
-                                } },
+                                "count": {
+                                    "$ifNull": [
+                                        {
+                                            "$getField": {
+                                                "field": "result",
+                                                "input": { "$first": { "$getField": { "$literal": "count" } } }
+                                            }
+                                        },
+                                        0,
+                                    ]
+                                },
                             },
                             "rows": "$__ROWS__",
                         } },
@@ -344,10 +351,17 @@ mod tests {
                         } },
                         { "$replaceWith": {
                             "aggregates": {
-                                "count": { "$getField": {
-                                    "field": "result",
-                                    "input": { "$first": { "$getField": { "$literal": "count" } } }
-                                } },
+                                "count": {
+                                    "$ifNull": [
+                                        {
+                                            "$getField": {
+                                                "field": "result",
+                                                "input": { "$first": { "$getField": { "$literal": "count" } } }
+                                            }
+                                        },
+                                        0,
+                                    ]
+                                },
                             },
                         } },
                     ]

--- a/crates/mongodb-agent-common/src/query/mod.rs
+++ b/crates/mongodb-agent-common/src/query/mod.rs
@@ -131,10 +131,17 @@ mod tests {
                             "field": "result",
                             "input": { "$first": { "$getField": { "$literal": "avg" } } },
                         } },
-                        "count": { "$getField": {
-                            "field": "result",
-                            "input": { "$first": { "$getField": { "$literal": "count" } } },
-                        } },
+                        "count": {
+                            "$ifNull": [
+                                {
+                                    "$getField": {
+                                        "field": "result",
+                                        "input": { "$first": { "$getField": { "$literal": "count" } } },
+                                    }
+                                },
+                                0,
+                            ]
+                        },
                     },
                 },
             },

--- a/crates/mongodb-agent-common/src/query/relations.rs
+++ b/crates/mongodb-agent-common/src/query/relations.rs
@@ -636,10 +636,15 @@ mod tests {
                             "$replaceWith": {
                                 "aggregates": {
                                     "aggregate_count": {
-                                        "$getField": {
-                                            "field": "result",
-                                            "input": { "$first": { "$getField": { "$literal": "aggregate_count" } } },
-                                        },
+                                        "$ifNull": [
+                                            {
+                                                "$getField": {
+                                                    "field": "result",
+                                                    "input": { "$first": { "$getField": { "$literal": "aggregate_count" } } },
+                                                },
+                                            },
+                                            0,
+                                        ]
                                     },
                                 },
                             },


### PR DESCRIPTION
Fix for count aggregates in cases where the query does not match any rows. Previously the connector returned null which is an appropriate response for other aggregations (like sum), but not for counts. This change fixes the problem by substituting zero for null for count aggregates only.

This is a port of a fix for the same issue from the v2 agent.

Ticket: [GDC-1345](https://hasurahq.atlassian.net/browse/GDC-1345)

[GDC-1345]: https://hasurahq.atlassian.net/browse/GDC-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ