### PR TITLE
add aggregate expression types to fixture metadata

### DIFF
--- a/fixtures/hasura/chinook/metadata/models/Invoice.hml
+++ b/fixtures/hasura/chinook/metadata/models/Invoice.hml
@@ -185,6 +185,7 @@ definition:
     aggregate:
       queryRootField:
         invoiceAggregate
+    filterInputTypeName: InvoiceFilterInput
     selectMany:
       queryRootField: invoice
     selectUniques:

--- a/fixtures/hasura/chinook/metadata/models/Invoice.hml
+++ b/fixtures/hasura/chinook/metadata/models/Invoice.hml
@@ -148,6 +148,7 @@ definition:
   source:
     dataConnectorName: chinook
     collection: Invoice
+  aggregateExpression: InvoiceAggregateExp
   filterExpressionType: InvoiceComparisonExp
   orderableFields:
     - fieldName: id
@@ -181,6 +182,9 @@ definition:
       orderByDirections:
         enableAll: true
   graphql:
+    aggregate:
+      queryRootField:
+        invoiceAggregate
     selectMany:
       queryRootField: invoice
     selectUniques:

--- a/fixtures/hasura/chinook/metadata/models/Invoice.hml
+++ b/fixtures/hasura/chinook/metadata/models/Invoice.hml
@@ -125,6 +125,21 @@ definition:
     typeName: InvoiceComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: InvoiceAggregateExp
+  operand:
+    object:
+      aggregatedType: Invoice
+      aggregatableFields:
+        - fieldName: total
+          aggregateExpression: DecimalAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: InvoiceAggregateExp
+
+---
 kind: Model
 version: v1
 definition:

--- a/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
+++ b/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
@@ -93,6 +93,23 @@ definition:
     typeName: InvoiceLineComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: InvoiceLineAggregateExp
+  operand:
+    object:
+      aggregatedType: InvoiceLine
+      aggregatableFields:
+        - fieldName: quantity
+          aggregateExpression: IntAggregateExp
+        - fieldName: unitPrice
+          aggregateExpression: DecimalAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: InvoiceLineAggregateExp
+
+---
 kind: Model
 version: v1
 definition:

--- a/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
+++ b/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
@@ -143,6 +143,7 @@ definition:
     aggregate:
       queryRootField:
         invoiceLineAggregate
+    filterInputTypeName: InvoiceLineFilterInput
     selectMany:
       queryRootField: invoiceLine
     selectUniques:

--- a/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
+++ b/fixtures/hasura/chinook/metadata/models/InvoiceLine.hml
@@ -118,6 +118,7 @@ definition:
   source:
     dataConnectorName: chinook
     collection: InvoiceLine
+  aggregateExpression: InvoiceLineAggregateExp
   filterExpressionType: InvoiceLineComparisonExp
   orderableFields:
     - fieldName: id
@@ -139,6 +140,9 @@ definition:
       orderByDirections:
         enableAll: true
   graphql:
+    aggregate:
+      queryRootField:
+        invoiceLineAggregate
     selectMany:
       queryRootField: invoiceLine
     selectUniques:

--- a/fixtures/hasura/chinook/metadata/models/Track.hml
+++ b/fixtures/hasura/chinook/metadata/models/Track.hml
@@ -141,6 +141,7 @@ definition:
       aggregatableFields:
         - fieldName: unitPrice
           aggregateExpression: DecimalAggregateExp
+  count: { enable: true }
   graphql:
     selectTypeName: TrackAggregateExp
 

--- a/fixtures/hasura/chinook/metadata/models/Track.hml
+++ b/fixtures/hasura/chinook/metadata/models/Track.hml
@@ -141,6 +141,10 @@ definition:
       aggregatableFields:
         - fieldName: unitPrice
           aggregateExpression: DecimalAggregateExp
+        - fieldName: bytes
+          aggregateExpression: IntAggregateExp
+        - fieldName: milliseconds
+          aggregateExpression: IntAggregateExp
   count: { enable: true }
   graphql:
     selectTypeName: TrackAggregateExp

--- a/fixtures/hasura/chinook/metadata/models/Track.hml
+++ b/fixtures/hasura/chinook/metadata/models/Track.hml
@@ -131,6 +131,20 @@ definition:
     typeName: TrackComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: TrackAggregateExp
+  operand:
+    object:
+      aggregatedType: Track
+      aggregatableFields:
+        - fieldName: unitPrice
+          aggregateExpression: DecimalAggregateExp
+  graphql:
+    selectTypeName: TrackAggregateExp
+
+---
 kind: Model
 version: v1
 definition:
@@ -139,6 +153,7 @@ definition:
   source:
     dataConnectorName: chinook
     collection: Track
+  aggregateExpression: TrackAggregateExp
   filterExpressionType: TrackComparisonExp
   orderableFields:
     - fieldName: id
@@ -172,6 +187,10 @@ definition:
       orderByDirections:
         enableAll: true
   graphql:
+    aggregate:
+      queryRootField:
+        trackAggregate
+    filterInputTypeName: TrackFilterInput
     selectMany:
       queryRootField: track
     selectUniques:

--- a/fixtures/hasura/common/metadata/scalar-types/Date.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Date.hml
@@ -69,3 +69,32 @@ definition:
   graphql:
     typeName: DateComparisonExp
 
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: DateAggregateExp
+  operand:
+    scalar:
+      aggregatedType: Date
+      aggregationFunctions:
+        - name: _max
+          returnType: Date
+        - name: _min
+          returnType: Date
+      dataConnectorAggregationFunctionMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: Date
+          functionMapping:
+            _max: { name: max }
+            _min: { name: min }
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: Date
+          functionMapping:
+            _max: { name: max }
+            _min: { name: min }
+  count: { enable: true }
+  countDistinct: { enable: true }
+  graphql:
+    selectTypeName: DateAggregateExp
+

--- a/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
@@ -68,3 +68,42 @@ definition:
     enable: true
   graphql:
     typeName: DecimalComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: DecimalAggregateExp
+  operand:
+    scalar:
+      aggregatedType: Decimal
+      aggregationFunctions:
+        - name: avg
+          returnType: Decimal
+        - name: count
+          returnType: Int
+        - name: max
+          returnType: Decimal
+        - name: min
+          returnType: Decimal
+        - name: sum
+          returnType: Decimal
+      dataConnectorAggregationFunctionMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: Decimal
+          functionMapping:
+            avg: { name: avg }
+            count: { name: count }
+            max: { name: max }
+            min: { name: min }
+            sum: { name: sum }
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: Decimal
+          functionMapping:
+            avg: { name: avg }
+            count: { name: count }
+            max: { name: max }
+            min: { name: min }
+            sum: { name: sum }
+  graphql:
+    selectTypeName: DecimalAggregateExp

--- a/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
@@ -78,32 +78,32 @@ definition:
     scalar:
       aggregatedType: Decimal
       aggregationFunctions:
-        - name: avg
+        - name: _avg
           returnType: Decimal
-        - name: count
-          returnType: Int
-        - name: max
+        - name: _max
           returnType: Decimal
-        - name: min
+        - name: _min
           returnType: Decimal
-        - name: sum
+        - name: _sum
           returnType: Decimal
       dataConnectorAggregationFunctionMapping:
         - dataConnectorName: chinook
           dataConnectorScalarType: Decimal
           functionMapping:
-            avg: { name: avg }
-            count: { name: count }
-            max: { name: max }
-            min: { name: min }
-            sum: { name: sum }
+            _avg: { name: avg }
+            _count: { name: count }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
         - dataConnectorName: sample_mflix
           dataConnectorScalarType: Decimal
           functionMapping:
-            avg: { name: avg }
-            count: { name: count }
-            max: { name: max }
-            min: { name: min }
-            sum: { name: sum }
+            _avg: { name: avg }
+            _count: { name: count }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+  count: { enable: true }
+  countDistinct: { enable: true }
   graphql:
     selectTypeName: DecimalAggregateExp

--- a/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
@@ -91,7 +91,6 @@ definition:
           dataConnectorScalarType: Decimal
           functionMapping:
             _avg: { name: avg }
-            _count: { name: count }
             _max: { name: max }
             _min: { name: min }
             _sum: { name: sum }
@@ -99,7 +98,6 @@ definition:
           dataConnectorScalarType: Decimal
           functionMapping:
             _avg: { name: avg }
-            _count: { name: count }
             _max: { name: max }
             _min: { name: min }
             _sum: { name: sum }

--- a/fixtures/hasura/common/metadata/scalar-types/Double.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Double.hml
@@ -60,3 +60,40 @@ definition:
     enable: true
   graphql:
     typeName: DoubleComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: FloatAggregateExp
+  operand:
+    scalar:
+      aggregatedType: Float
+      aggregationFunctions:
+        - name: _avg
+          returnType: Float
+        - name: _max
+          returnType: Float
+        - name: _min
+          returnType: Float
+        - name: _sum
+          returnType: Float
+      dataConnectorAggregationFunctionMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: Double
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: Double
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+  count: { enable: true }
+  countDistinct: { enable: true }
+  graphql:
+    selectTypeName: FloatAggregateExp

--- a/fixtures/hasura/common/metadata/scalar-types/Int.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Int.hml
@@ -60,3 +60,40 @@ definition:
     enable: true
   graphql:
     typeName: IntComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: IntAggregateExp
+  operand:
+    scalar:
+      aggregatedType: Int
+      aggregationFunctions:
+        - name: _avg
+          returnType: Int
+        - name: _max
+          returnType: Int
+        - name: _min
+          returnType: Int
+        - name: _sum
+          returnType: Int
+      dataConnectorAggregationFunctionMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: Int
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: Int
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+  count: { enable: true }
+  countDistinct: { enable: true }
+  graphql:
+    selectTypeName: IntAggregateExp

--- a/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
@@ -124,6 +124,7 @@ definition:
   source:
     dataConnectorName: sample_mflix
     collection: comments
+  aggregateExpression: CommentsAggregateExp
   filterExpressionType: CommentsComparisonExp
   orderableFields:
     - fieldName: id
@@ -148,6 +149,7 @@ definition:
     aggregate:
       queryRootField:
         commentsAggregate
+    filterInputTypeName: CommentsFilterInput
     selectMany:
       queryRootField: comments
     selectUniques:

--- a/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
@@ -101,6 +101,21 @@ definition:
     typeName: CommentsComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: CommentsAggregateExp
+  operand:
+    object:
+      aggregatedType: Comments
+      aggregatableFields:
+        - fieldName: date
+          aggregateExpression: DateAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: CommentsAggregateExp
+
+---
 kind: Model
 version: v1
 definition:

--- a/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
@@ -145,6 +145,9 @@ definition:
       orderByDirections:
         enableAll: true
   graphql:
+    aggregate:
+      queryRootField:
+        commentsAggregate
     selectMany:
       queryRootField: comments
     selectUniques:

--- a/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Comments.hml
@@ -147,8 +147,7 @@ definition:
         enableAll: true
   graphql:
     aggregate:
-      queryRootField:
-        commentsAggregate
+      queryRootField: commentsAggregate
     filterInputTypeName: CommentsFilterInput
     selectMany:
       queryRootField: comments
@@ -169,12 +168,12 @@ definition:
         filter: null
     - role: user
       select:
-        filter: 
+        filter:
           relationship:
             name: user
-            predicate: 
+            predicate:
               fieldComparison:
                 field: id
                 operator: _eq
-                value:  
+                value:
                   sessionVariable: x-hasura-user-id

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -54,6 +54,23 @@ definition:
     typeName: MoviesAwardsComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesAwardsAggregateExp
+  operand:
+    object:
+      aggregatedType: MoviesAwards
+      aggregatableFields:
+        - fieldName: nominations
+          aggregateExpression: IntAggregateExp
+        - fieldName: wins
+          aggregateExpression: IntAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesAwardsAggregateExp
+
+---
 kind: ObjectType
 version: v1
 definition:
@@ -107,6 +124,23 @@ definition:
     enable: true
   graphql:
     typeName: MoviesImdbComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesImdbAggregateExp
+  operand:
+    object:
+      aggregatedType: MoviesImdb
+      aggregatableFields:
+        - fieldName: rating
+          aggregateExpression: FloatAggregateExp
+        - fieldName: votes
+          aggregateExpression: IntAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesImdbAggregateExp
 
 ---
 kind: ObjectType
@@ -164,6 +198,25 @@ definition:
     typeName: MoviesTomatoesCriticComparisonExp
 
 ---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesTomatoesCriticAggregateExp
+  operand:
+    object:
+      aggregatedType: MoviesTomatoesCritic
+      aggregatableFields:
+        - fieldName: meter
+          aggregateExpression: IntAggregateExp
+        - fieldName: numReviews
+          aggregateExpression: IntAggregateExp
+        - fieldName: rating
+          aggregateExpression: FloatAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesTomatoesCriticAggregateExp
+
+---
 kind: ObjectType
 version: v1
 definition:
@@ -217,6 +270,25 @@ definition:
     enable: true
   graphql:
     typeName: MoviesTomatoesViewerComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesTomatoesViewerAggregateExp
+  operand:
+    object:
+      aggregatedType: MoviesTomatoesViewer
+      aggregatableFields:
+        - fieldName: meter
+          aggregateExpression: IntAggregateExp
+        - fieldName: numReviews
+          aggregateExpression: IntAggregateExp
+        - fieldName: rating
+          aggregateExpression: FloatAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesTomatoesViewerAggregateExp
 
 ---
 kind: ObjectType
@@ -307,6 +379,29 @@ definition:
     enable: true
   graphql:
     typeName: MoviesTomatoesComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesTomatoesAggregateExp
+  operand:
+    object:
+      aggregatedType: MoviesTomatoes
+      aggregatableFields:
+        - fieldName: critic
+          aggregateExpression: MoviesTomatoesCriticAggregateExp
+        - fieldName: dvd
+          aggregateExpression: DateAggregateExp
+        - fieldName: fresh
+          aggregateExpression: IntAggregateExp
+        - fieldName: rotten
+          aggregateExpression: IntAggregateExp
+        - fieldName: viewer
+          aggregateExpression: MoviesTomatoesViewerAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesTomatoesAggregateExp
 
 ---
 kind: ObjectType
@@ -514,6 +609,35 @@ definition:
     enable: true
   graphql:
     typeName: MoviesComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: MoviesAggregateExp
+  operand:
+    object:
+      aggregatedType: Movies
+      aggregatableFields:
+        - fieldName: awards
+          aggregateExpression: MoviesAwardsAggregateExp
+        - fieldName: imdb
+          aggregateExpression: MoviesImdbAggregateExp
+        - fieldName: metacritic
+          aggregateExpression: IntAggregateExp
+        - fieldName: numMflixComments
+          aggregateExpression: IntAggregateExp
+        - fieldName: released
+          aggregateExpression: DateAggregateExp
+        - fieldName: runtime
+          aggregateExpression: IntAggregateExp
+        - fieldName: tomatoes
+          aggregateExpression: MoviesTomatoesAggregateExp
+        - fieldName: year
+          aggregateExpression: IntAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: MoviesAggregateExp
 
 ---
 kind: Model

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -619,10 +619,12 @@ definition:
     object:
       aggregatedType: Movies
       aggregatableFields:
-        - fieldName: awards
-          aggregateExpression: MoviesAwardsAggregateExp
-        - fieldName: imdb
-          aggregateExpression: MoviesImdbAggregateExp
+        # TODO: This requires updating the connector to support nested field
+        # aggregates
+        # - fieldName: awards
+        #   aggregateExpression: MoviesAwardsAggregateExp
+        # - fieldName: imdb
+        #   aggregateExpression: MoviesImdbAggregateExp
         - fieldName: metacritic
           aggregateExpression: IntAggregateExp
         - fieldName: numMflixComments
@@ -631,8 +633,8 @@ definition:
           aggregateExpression: DateAggregateExp
         - fieldName: runtime
           aggregateExpression: IntAggregateExp
-        - fieldName: tomatoes
-          aggregateExpression: MoviesTomatoesAggregateExp
+        # - fieldName: tomatoes
+        #   aggregateExpression: MoviesTomatoesAggregateExp
         - fieldName: year
           aggregateExpression: IntAggregateExp
   count: { enable: true }

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -648,6 +648,7 @@ definition:
   source:
     dataConnectorName: sample_mflix
     collection: movies
+  aggregateExpression: MoviesAggregateExp
   filterExpressionType: MoviesComparisonExp
   orderableFields:
     - fieldName: id
@@ -717,6 +718,9 @@ definition:
       orderByDirections:
         enableAll: true
   graphql:
+    aggregate:
+      queryRootField:
+        moviesAggregate
     selectMany:
       queryRootField: movies
     selectUniques:

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -307,7 +307,7 @@ definition:
     - name: fresh
       type: Int
     - name: lastUpdated
-      type: String!
+      type: Date!
     - name: production
       type: String
     - name: rotten
@@ -363,7 +363,7 @@ definition:
         - fieldName: fresh
           booleanExpressionType: IntComparisonExp
         - fieldName: lastUpdated
-          booleanExpressionType: StringComparisonExp
+          booleanExpressionType: DateComparisonExp
         - fieldName: production
           booleanExpressionType: StringComparisonExp
         - fieldName: rotten
@@ -395,6 +395,8 @@ definition:
           aggregateExpression: DateAggregateExp
         - fieldName: fresh
           aggregateExpression: IntAggregateExp
+        - fieldName: lastUpdated
+          aggregateExpression: DateAggregateExp
         - fieldName: rotten
           aggregateExpression: IntAggregateExp
         - fieldName: viewer
@@ -428,7 +430,7 @@ definition:
     - name: languages
       type: "[String!]"
     - name: lastupdated
-      type: Date!
+      type: String!
     - name: metacritic
       type: Int
     - name: numMflixComments
@@ -577,7 +579,7 @@ definition:
         - fieldName: imdb
           booleanExpressionType: MoviesImdbComparisonExp
         - fieldName: lastupdated
-          booleanExpressionType: DateComparisonExp
+          booleanExpressionType: StringComparisonExp
         - fieldName: metacritic
           booleanExpressionType: IntComparisonExp
         - fieldName: numMflixComments
@@ -721,8 +723,7 @@ definition:
         enableAll: true
   graphql:
     aggregate:
-      queryRootField:
-        moviesAggregate
+      queryRootField: moviesAggregate
     filterInputTypeName: MoviesFilterInput
     selectMany:
       queryRootField: movies
@@ -741,4 +742,3 @@ definition:
     - role: admin
       select:
         filter: null
-

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -723,6 +723,7 @@ definition:
     aggregate:
       queryRootField:
         moviesAggregate
+    filterInputTypeName: MoviesFilterInput
     selectMany:
       queryRootField: movies
     selectUniques:

--- a/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
+++ b/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
@@ -964,7 +964,7 @@ definition:
             name: String
       procedures: []
     capabilities:
-      version: 0.1.4
+      version: 0.1.5
       capabilities:
         query:
           aggregates: {}


### PR DESCRIPTION
Once again, this only affects integration tests and the local dev environment.

Adds aggregation expression types for everything that looks it should be aggregatable. The connector isn't advertising support for nested field aggregates yet so the nested field aggregates are commented out for now. I filed [NDC-386](https://linear.app/hasura/issue/NDC-386/update-capabilities-to-support-nested-aggregates) to follow up on that. Everything looks good in ad-hoc testing. I'm planning to follow up with integration tests shortly.

Completes [NDC-381](https://linear.app/hasura/issue/NDC-381/update-metadata-fixtures-to-configure-aggregations)