### PR TITLE
serialize aggregate results as simple instead of extended json

### DIFF
--- a/crates/integration-tests/src/tests/aggregation.rs
+++ b/crates/integration-tests/src/tests/aggregation.rs
@@ -1,0 +1,32 @@
+use insta::assert_yaml_snapshot;
+
+use crate::graphql_query;
+
+#[tokio::test]
+async fn runs_aggregation_over_top_level_fields() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+                query {
+                  track(limit: 3) {
+                    unitPrice
+                  }
+                  trackAggregate(filter_input: {limit: 3}) {
+                    _count
+                    unitPrice {
+                      _count
+                      _count_distinct
+                      _avg
+                      _max
+                      _min
+                      _sum
+                    }
+                  }
+                }
+            "#
+        )
+        .run()
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/mod.rs
+++ b/crates/integration-tests/src/tests/mod.rs
@@ -7,6 +7,7 @@
 //     rust-analyzer.cargo.allFeatures = true
 //
 
+mod aggregation;
 mod basic;
 mod local_relationship;
 mod native_mutation;

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__runs_aggregation_over_top_level_fields.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__runs_aggregation_over_top_level_fields.snap
@@ -1,19 +1,33 @@
 ---
 source: crates/integration-tests/src/tests/aggregation.rs
-expression: "graphql_query(r#\"\n                query {\n                  track(limit: 3) {\n                    unitPrice\n                  }\n                  trackAggregate(filter_input: {limit: 3}) {\n                    _count\n                    unitPrice {\n                      _count\n                      _count_distinct\n                      _avg\n                      _max\n                      _min\n                      _sum\n                    }\n                  }\n                }\n            \"#).run().await?"
+expression: "graphql_query(r#\"\n                query($albumId: Int!) {\n                  track(order_by: { id: Asc }, where: { albumId: { _eq: $albumId } }) {\n                    milliseconds\n                    unitPrice\n                  }\n                  trackAggregate(\n                    filter_input: { order_by: { id: Asc }, where: { albumId: { _eq: $albumId } } }\n                  ) {\n                    _count\n                    milliseconds {\n                      _avg\n                      _max\n                      _min\n                      _sum\n                    }\n                    unitPrice {\n                      _count\n                      _count_distinct\n                    }\n                  }\n                }\n            \"#).variables(json!({\n                        \"albumId\": 9\n                    })).run().await?"
 ---
 data:
   track:
-    - unitPrice: "0.99"
-    - unitPrice: "0.99"
-    - unitPrice: "0.99"
+    - milliseconds: 221701
+      unitPrice: "0.99"
+    - milliseconds: 436453
+      unitPrice: "0.99"
+    - milliseconds: 374543
+      unitPrice: "0.99"
+    - milliseconds: 322925
+      unitPrice: "0.99"
+    - milliseconds: 288208
+      unitPrice: "0.99"
+    - milliseconds: 308035
+      unitPrice: "0.99"
+    - milliseconds: 369345
+      unitPrice: "0.99"
+    - milliseconds: 350197
+      unitPrice: "0.99"
   trackAggregate:
-    _count: 3
+    _count: 8
+    milliseconds:
+      _avg: 333925.875
+      _max: 436453
+      _min: 221701
+      _sum: 2671407
     unitPrice:
-      _count: 3
+      _count: 8
       _count_distinct: 1
-      _avg: "0.99"
-      _max: "0.99"
-      _min: "0.99"
-      _sum: "2.97"
 errors: ~

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__runs_aggregation_over_top_level_fields.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__runs_aggregation_over_top_level_fields.snap
@@ -1,0 +1,19 @@
+---
+source: crates/integration-tests/src/tests/aggregation.rs
+expression: "graphql_query(r#\"\n                query {\n                  track(limit: 3) {\n                    unitPrice\n                  }\n                  trackAggregate(filter_input: {limit: 3}) {\n                    _count\n                    unitPrice {\n                      _count\n                      _count_distinct\n                      _avg\n                      _max\n                      _min\n                      _sum\n                    }\n                  }\n                }\n            \"#).run().await?"
+---
+data:
+  track:
+    - unitPrice: "0.99"
+    - unitPrice: "0.99"
+    - unitPrice: "0.99"
+  trackAggregate:
+    _count: 3
+    unitPrice:
+      _count: 3
+      _count_distinct: 1
+      _avg: "0.99"
+      _max: "0.99"
+      _min: "0.99"
+      _sum: "2.97"
+errors: ~

--- a/crates/mongodb-agent-common/src/query/response.rs
+++ b/crates/mongodb-agent-common/src/query/response.rs
@@ -138,7 +138,7 @@ fn serialize_aggregates(
     query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>,
     value: Bson,
 ) -> Result<IndexMap<ndc_models::FieldName, serde_json::Value>> {
-    let aggregates_type = type_for_aggregates(query_aggregates)?;
+    let aggregates_type = type_for_aggregates(query_aggregates);
     let json = bson_to_json(mode, &aggregates_type, value)?;
 
     // The NDC type uses an IndexMap for aggregate values; we need to convert the map
@@ -185,7 +185,7 @@ fn type_for_row_set(
     let mut type_fields = BTreeMap::new();
 
     if let Some(aggregates) = aggregates {
-        type_fields.insert("aggregates".into(), type_for_aggregates(aggregates)?);
+        type_fields.insert("aggregates".into(), type_for_aggregates(aggregates));
     }
 
     if let Some(query_fields) = fields {
@@ -199,9 +199,7 @@ fn type_for_row_set(
     }))
 }
 
-fn type_for_aggregates(
-    query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>,
-) -> Result<Type> {
+fn type_for_aggregates(query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>) -> Type {
     let fields = query_aggregates
         .iter()
         .map(|(field_name, aggregate)| {
@@ -219,7 +217,7 @@ fn type_for_aggregates(
             )
         })
         .collect();
-    Ok(Type::Object(ObjectType { fields, name: None }))
+    Type::Object(ObjectType { fields, name: None })
 }
 
 fn type_for_row(

--- a/crates/mongodb-agent-common/src/query/response.rs
+++ b/crates/mongodb-agent-common/src/query/response.rs
@@ -135,10 +135,10 @@ fn serialize_row_set_with_aggregates(
 fn serialize_aggregates(
     mode: ExtendedJsonMode,
     path: &[&str],
-    _query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>,
+    query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>,
     value: Bson,
 ) -> Result<IndexMap<ndc_models::FieldName, serde_json::Value>> {
-    let aggregates_type = type_for_aggregates()?;
+    let aggregates_type = type_for_aggregates(query_aggregates)?;
     let json = bson_to_json(mode, &aggregates_type, value)?;
 
     // The NDC type uses an IndexMap for aggregate values; we need to convert the map
@@ -184,8 +184,8 @@ fn type_for_row_set(
 ) -> Result<Type> {
     let mut type_fields = BTreeMap::new();
 
-    if aggregates.is_some() {
-        type_fields.insert("aggregates".into(), type_for_aggregates()?);
+    if let Some(aggregates) = aggregates {
+        type_fields.insert("aggregates".into(), type_for_aggregates(aggregates)?);
     }
 
     if let Some(query_fields) = fields {
@@ -199,9 +199,27 @@ fn type_for_row_set(
     }))
 }
 
-// TODO: infer response type for aggregates MDB-130
-fn type_for_aggregates() -> Result<Type> {
-    Ok(Type::Scalar(MongoScalarType::ExtendedJSON))
+fn type_for_aggregates(
+    query_aggregates: &IndexMap<ndc_models::FieldName, Aggregate>,
+) -> Result<Type> {
+    let fields = query_aggregates
+        .iter()
+        .map(|(field_name, aggregate)| {
+            (
+                field_name.to_string().into(),
+                match aggregate {
+                    Aggregate::ColumnCount { .. } => {
+                        Type::Scalar(MongoScalarType::Bson(mongodb_support::BsonScalarType::Int))
+                    }
+                    Aggregate::StarCount => {
+                        Type::Scalar(MongoScalarType::Bson(mongodb_support::BsonScalarType::Int))
+                    }
+                    Aggregate::SingleColumn { result_type, .. } => result_type.clone(),
+                },
+            )
+        })
+        .collect();
+    Ok(Type::Object(ObjectType { fields, name: None }))
 }
 
 fn type_for_row(


### PR DESCRIPTION
This makes serialization for aggregate results behave the same as serialization for non-aggregate query responses.