### PR TITLE
support all comparison and aggregation functions on extended json fields

### DIFF
--- a/crates/integration-tests/src/tests/aggregation.rs
+++ b/crates/integration-tests/src/tests/aggregation.rs
@@ -43,31 +43,59 @@ async fn aggregates_extended_json_representing_mixture_of_numeric_types() -> any
     assert_yaml_snapshot!(
         graphql_query(
             r#"
-                query {
-
-                  track(order_by: { id: Asc }, where: { albumId: { _eq: $albumId } }) {
-                    milliseconds
-                    unitPrice
-                  }
-                  trackAggregate(
-                    filter_input: { order_by: { id: Asc }, where: { albumId: { _eq: $albumId } } }
+                query ($types: String!) {
+                  extendedJsonTestDataAggregate(
+                    filter_input: { where: { type: { _regex: $types } } }
                   ) {
-                    _count
-                    milliseconds {
+                    value {
                       _avg
+                      _count
                       _max
                       _min
                       _sum
-                    }
-                    unitPrice {
-                      _count
                       _count_distinct
                     }
+                  }
+                  extendedJsonTestData(where: { type: { _regex: $types } }) {
+                    type
+                    value
                   }
                 }
             "#
         )
-        .variables(json!({ "albumId": 9 }))
+        .variables(json!({ "types": "decimal|double|int|long" }))
+        .run()
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn aggregates_mixture_of_numeric_and_null_values() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+                query ($types: String!) {
+                  extendedJsonTestDataAggregate(
+                    filter_input: { where: { type: { _regex: $types } } }
+                  ) {
+                    value {
+                      _avg
+                      _count
+                      _max
+                      _min
+                      _sum
+                      _count_distinct
+                    }
+                  }
+                  extendedJsonTestData(where: { type: { _regex: $types } }) {
+                    type
+                    value
+                  }
+                }
+            "#
+        )
+        .variables(json!({ "types": "double|null" }))
         .run()
         .await?
     );

--- a/crates/integration-tests/src/tests/aggregation.rs
+++ b/crates/integration-tests/src/tests/aggregation.rs
@@ -37,3 +37,39 @@ async fn runs_aggregation_over_top_level_fields() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn aggregates_extended_json_representing_mixture_of_numeric_types() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+                query {
+
+                  track(order_by: { id: Asc }, where: { albumId: { _eq: $albumId } }) {
+                    milliseconds
+                    unitPrice
+                  }
+                  trackAggregate(
+                    filter_input: { order_by: { id: Asc }, where: { albumId: { _eq: $albumId } } }
+                  ) {
+                    _count
+                    milliseconds {
+                      _avg
+                      _max
+                      _min
+                      _sum
+                    }
+                    unitPrice {
+                      _count
+                      _count_distinct
+                    }
+                  }
+                }
+            "#
+        )
+        .variables(json!({ "albumId": 9 }))
+        .run()
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/filtering.rs
+++ b/crates/integration-tests/src/tests/filtering.rs
@@ -1,0 +1,24 @@
+use insta::assert_yaml_snapshot;
+use serde_json::json;
+
+use crate::graphql_query;
+
+#[tokio::test]
+async fn filters_on_extended_json_using_string_comparison() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+                query Filtering {
+                  extendedJsonTestData(where: { value: { _regex: "hello" } }) {
+                    type
+                    value
+                  }
+                }
+            "#
+        )
+        .variables(json!({ "types": "double|null" }))
+        .run()
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/mod.rs
+++ b/crates/integration-tests/src/tests/mod.rs
@@ -9,6 +9,7 @@
 
 mod aggregation;
 mod basic;
+mod filtering;
 mod local_relationship;
 mod native_mutation;
 mod native_query;

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__aggregates_extended_json_representing_mixture_of_numeric_types.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__aggregates_extended_json_representing_mixture_of_numeric_types.snap
@@ -1,0 +1,43 @@
+---
+source: crates/integration-tests/src/tests/aggregation.rs
+expression: "graphql_query(r#\"\n                query ($types: String!) {\n                  extendedJsonTestDataAggregate(\n                    filter_input: { where: { type: { _regex: $types } } }\n                  ) {\n                    value {\n                      _avg\n                      _count\n                      _max\n                      _min\n                      _sum\n                      _count_distinct\n                    }\n                  }\n                  extendedJsonTestData(where: { type: { _regex: $types } }) {\n                    type\n                    value\n                  }\n                }\n            \"#).variables(json!({\n                        \"types\": \"decimal|double|int|long\"\n                    })).run().await?"
+---
+data:
+  extendedJsonTestDataAggregate:
+    value:
+      _avg:
+        $numberDecimal: "4.5"
+      _count: 8
+      _max:
+        $numberLong: "8"
+      _min:
+        $numberDecimal: "1"
+      _sum:
+        $numberDecimal: "36"
+      _count_distinct: 8
+  extendedJsonTestData:
+    - type: decimal
+      value:
+        $numberDecimal: "1"
+    - type: decimal
+      value:
+        $numberDecimal: "2"
+    - type: double
+      value:
+        $numberDouble: "3.0"
+    - type: double
+      value:
+        $numberDouble: "4.0"
+    - type: int
+      value:
+        $numberInt: "5"
+    - type: int
+      value:
+        $numberInt: "6"
+    - type: long
+      value:
+        $numberLong: "7"
+    - type: long
+      value:
+        $numberLong: "8"
+errors: ~

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__aggregates_mixture_of_numeric_and_null_values.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__aggregation__aggregates_mixture_of_numeric_and_null_values.snap
@@ -1,0 +1,27 @@
+---
+source: crates/integration-tests/src/tests/aggregation.rs
+expression: "graphql_query(r#\"\n                query ($types: String!) {\n                  extendedJsonTestDataAggregate(\n                    filter_input: { where: { type: { _regex: $types } } }\n                  ) {\n                    value {\n                      _avg\n                      _count\n                      _max\n                      _min\n                      _sum\n                      _count_distinct\n                    }\n                  }\n                  extendedJsonTestData(where: { type: { _regex: $types } }) {\n                    type\n                    value\n                  }\n                }\n            \"#).variables(json!({\n                        \"types\": \"double|null\"\n                    })).run().await?"
+---
+data:
+  extendedJsonTestDataAggregate:
+    value:
+      _avg:
+        $numberDouble: "3.5"
+      _count: 2
+      _max:
+        $numberDouble: "4.0"
+      _min:
+        $numberDouble: "3.0"
+      _sum:
+        $numberDouble: "7.0"
+      _count_distinct: 2
+  extendedJsonTestData:
+    - type: double
+      value:
+        $numberDouble: "3.0"
+    - type: double
+      value:
+        $numberDouble: "4.0"
+    - type: "null"
+      value: ~
+errors: ~

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_on_extended_json_using_string_comparison.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_on_extended_json_using_string_comparison.snap
@@ -1,0 +1,9 @@
+---
+source: crates/integration-tests/src/tests/filtering.rs
+expression: "graphql_query(r#\"\n                query Filtering {\n                  extendedJsonTestData(where: { value: { _regex: \"hello\" } }) {\n                    type\n                    value\n                  }\n                }\n            \"#).variables(json!({\n                        \"types\": \"double|null\"\n                    })).run().await?"
+---
+data:
+  extendedJsonTestData:
+    - type: string
+      value: "hello, world!"
+errors: ~

--- a/fixtures/hasura/chinook/metadata/chinook.hml
+++ b/fixtures/hasura/chinook/metadata/chinook.hml
@@ -207,8 +207,65 @@ definition:
         ExtendedJSON:
           representation:
             type: json
-          aggregate_functions: {}
-          comparison_operators: {}
+          aggregate_functions:
+            avg:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            count:
+              result_type:
+                type: named
+                name: Int
+            max:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            min:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            sum:
+              result_type:
+                type: named
+                name: ExtendedJSON
+          comparison_operators:
+            _eq:
+              type: equal
+            _gt:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _gte:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _iregex:
+              type: custom
+              argument_type:
+                type: named
+                name: String
+            _lt:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _lte:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _neq:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _regex:
+              type: custom
+              argument_type:
+                type: named
+                name: String
         Int:
           representation:
             type: int32

--- a/fixtures/hasura/chinook/subgraph.yaml
+++ b/fixtures/hasura/chinook/subgraph.yaml
@@ -1,5 +1,5 @@
 kind: Subgraph
-version: v1
+version: v2
 definition:
   generator:
     rootPath: .

--- a/fixtures/hasura/common/metadata/scalar-types/ExtendedJSON.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/ExtendedJSON.hml
@@ -21,3 +21,95 @@ definition:
   dataConnectorName: sample_mflix
   dataConnectorScalarType: ExtendedJSON
   representation: ExtendedJSON
+
+---
+kind: BooleanExpressionType
+version: v1
+definition:
+  name: ExtendedJsonComparisonExp
+  operand:
+    scalar:
+      type: ExtendedJSON
+      comparisonOperators:
+        - name: _eq
+          argumentType: ExtendedJSON
+        - name: _neq
+          argumentType: ExtendedJSON
+        - name: _gt
+          argumentType: ExtendedJSON
+        - name: _gte
+          argumentType: ExtendedJSON
+        - name: _lt
+          argumentType: ExtendedJSON
+        - name: _lte
+          argumentType: ExtendedJSON
+        - name: _regex
+          argumentType: String
+        - name: _iregex
+          argumentType: String
+      dataConnectorOperatorMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: ExtendedJSON
+          operatorMapping:
+            _eq: _eq
+            _neq: _neq
+            _gt: _gt
+            _gte: _gte
+            _lt: _lt
+            _lte: _lte
+            _regex: _regex
+            _iregex: _iregex
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: ExtendedJSON
+          operatorMapping:
+            _eq: _eq
+            _neq: _neq
+            _gt: _gt
+            _gte: _gte
+            _lt: _lt
+            _lte: _lte
+            _regex: _regex
+            _iregex: _iregex
+  logicalOperators:
+    enable: true
+  isNull:
+    enable: true
+  graphql:
+    typeName: ExtendedJsonComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: ExtendedJsonAggregateExp
+  operand:
+    scalar:
+      aggregatedType: ExtendedJSON
+      aggregationFunctions:
+        - name: _avg
+          returnType: ExtendedJSON
+        - name: _max
+          returnType: ExtendedJSON
+        - name: _min
+          returnType: ExtendedJSON
+        - name: _sum
+          returnType: ExtendedJSON
+      dataConnectorAggregationFunctionMapping:
+        - dataConnectorName: chinook
+          dataConnectorScalarType: ExtendedJSON
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+        - dataConnectorName: sample_mflix
+          dataConnectorScalarType: ExtendedJSON
+          functionMapping:
+            _avg: { name: avg }
+            _max: { name: max }
+            _min: { name: min }
+            _sum: { name: sum }
+  count: { enable: true }
+  countDistinct: { enable: true }
+  graphql:
+    selectTypeName: ExtendedJsonAggregateExp

--- a/fixtures/hasura/sample_mflix/connector/sample_mflix/native_queries/extended_json_test_data.json
+++ b/fixtures/hasura/sample_mflix/connector/sample_mflix/native_queries/extended_json_test_data.json
@@ -1,0 +1,98 @@
+{
+  "name": "extended_json_test_data",
+  "representation": "collection",
+  "description": "various values that all have the ExtendedJSON type",
+  "resultDocumentType": "DocWithExtendedJsonValue",
+  "objectTypes": {
+    "DocWithExtendedJsonValue": {
+      "fields": {
+        "type": {
+          "type": {
+            "scalar": "string"
+          }
+        },
+        "value": {
+          "type": "extendedJSON"
+        }
+      }
+    }
+  },
+  "pipeline": [
+    {
+      "$documents": [
+        {
+          "type": "decimal",
+          "value": {
+            "$numberDecimal": "1"
+          }
+        },
+        {
+          "type": "decimal",
+          "value": {
+            "$numberDecimal": "2"
+          }
+        },
+        {
+          "type": "double",
+          "value": {
+            "$numberDouble": "3"
+          }
+        },
+        {
+          "type": "double",
+          "value": {
+            "$numberDouble": "4"
+          }
+        },
+        {
+          "type": "int",
+          "value": {
+            "$numberInt": "5"
+          }
+        },
+        {
+          "type": "int",
+          "value": {
+            "$numberInt": "6"
+          }
+        },
+        {
+          "type": "long",
+          "value": {
+            "$numberLong": "7"
+          }
+        },
+        {
+          "type": "long",
+          "value": {
+            "$numberLong": "8"
+          }
+        },
+        {
+          "type": "string",
+          "value": "foo"
+        },
+        {
+          "type": "string",
+          "value": "hello, world!"
+        },
+        {
+          "type": "date",
+          "value": {
+            "$date": "2024-08-20T14:38:00Z"
+          }
+        },
+        {
+          "type": "date",
+          "value": {
+            "$date": "2021-11-22T09:00:00Z"
+          }
+        },
+        {
+          "type": "null",
+          "value": null
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/hasura/sample_mflix/metadata/models/ExtendedJsonTestData.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/ExtendedJsonTestData.hml
@@ -1,0 +1,103 @@
+---
+kind: ObjectType
+version: v1
+definition:
+  name: DocWithExtendedJsonValue
+  fields:
+    - name: type
+      type: String!
+    - name: value
+      type: ExtendedJSON
+  graphql:
+    typeName: DocWithExtendedJsonValue
+    inputTypeName: DocWithExtendedJsonValueInput
+  dataConnectorTypeMapping:
+    - dataConnectorName: sample_mflix
+      dataConnectorObjectType: DocWithExtendedJsonValue
+
+---
+kind: TypePermissions
+version: v1
+definition:
+  typeName: DocWithExtendedJsonValue
+  permissions:
+    - role: admin
+      output:
+        allowedFields:
+          - type
+          - value
+
+---
+kind: BooleanExpressionType
+version: v1
+definition:
+  name: DocWithExtendedJsonValueComparisonExp
+  operand:
+    object:
+      type: DocWithExtendedJsonValue
+      comparableFields:
+        - fieldName: type
+          booleanExpressionType: StringComparisonExp
+        - fieldName: value
+          booleanExpressionType: ExtendedJsonComparisonExp
+      comparableRelationships: []
+  logicalOperators:
+    enable: true
+  isNull:
+    enable: true
+  graphql:
+    typeName: DocWithExtendedJsonValueComparisonExp
+
+---
+kind: AggregateExpression
+version: v1
+definition:
+  name: DocWithExtendedJsonValueAggregateExp
+  operand:
+    object:
+      aggregatedType: DocWithExtendedJsonValue
+      aggregatableFields:
+        - fieldName: value
+          aggregateExpression: ExtendedJsonAggregateExp
+  count: { enable: true }
+  graphql:
+    selectTypeName: DocWithExtendedJsonValueAggregateExp
+
+---
+kind: Model
+version: v1
+definition:
+  name: ExtendedJsonTestData
+  objectType: DocWithExtendedJsonValue
+  source:
+    dataConnectorName: sample_mflix
+    collection: extended_json_test_data
+  aggregateExpression: DocWithExtendedJsonValueAggregateExp
+  filterExpressionType: DocWithExtendedJsonValueComparisonExp
+  orderableFields:
+    - fieldName: type
+      orderByDirections:
+        enableAll: true
+    - fieldName: value
+      orderByDirections:
+        enableAll: true
+  graphql:
+    aggregate:
+      queryRootField: extendedJsonTestDataAggregate
+    filterInputTypeName: ExtendedJsonTestDataFilterInput
+    selectMany:
+      queryRootField: extendedJsonTestData
+    selectUniques: []
+    orderByExpressionType: ExtendedJsonTestDataOrderBy
+  description: various values that all have the ExtendedJSON type
+
+---
+kind: ModelPermissions
+version: v1
+definition:
+  modelName: ExtendedJsonTestData
+  permissions:
+    - role: admin
+      select:
+        filter: null
+

--- a/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
+++ b/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
@@ -207,8 +207,65 @@ definition:
         ExtendedJSON:
           representation:
             type: json
-          aggregate_functions: {}
-          comparison_operators: {}
+          aggregate_functions:
+            avg:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            count:
+              result_type:
+                type: named
+                name: Int
+            max:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            min:
+              result_type:
+                type: named
+                name: ExtendedJSON
+            sum:
+              result_type:
+                type: named
+                name: ExtendedJSON
+          comparison_operators:
+            _eq:
+              type: equal
+            _gt:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _gte:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _iregex:
+              type: custom
+              argument_type:
+                type: named
+                name: String
+            _lt:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _lte:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _neq:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _regex:
+              type: custom
+              argument_type:
+                type: named
+                name: String
         Int:
           representation:
             type: int32
@@ -517,6 +574,18 @@ definition:
                 type: named
                 name: Undefined
       object_types:
+        DocWithExtendedJsonValue:
+          fields:
+            type:
+              type:
+                type: named
+                name: String
+            value:
+              type:
+                type: nullable
+                underlying_type:
+                  type: named
+                  name: ExtendedJSON
         Hello:
           fields:
             __value:
@@ -909,6 +978,12 @@ definition:
             comments_id:
               unique_columns:
                 - _id
+          foreign_keys: {}
+        - name: extended_json_test_data
+          description: various values that all have the ExtendedJSON type
+          arguments: {}
+          type: DocWithExtendedJsonValue
+          uniqueness_constraints: {}
           foreign_keys: {}
         - name: movies
           arguments: {}

--- a/fixtures/hasura/sample_mflix/subgraph.yaml
+++ b/fixtures/hasura/sample_mflix/subgraph.yaml
@@ -1,5 +1,5 @@
 kind: Subgraph
-version: v1
+version: v2
 definition:
   generator:
     rootPath: .

--- a/flake.lock
+++ b/flake.lock
@@ -116,6 +116,24 @@
         "type": "indirect"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "graphql-engine-source": {
       "flake": false,
       "locked": {
@@ -148,6 +166,25 @@
         "type": "github"
       }
     },
+    "hasura-ddn-cli": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1723539998,
+        "narHash": "sha256-9w9uF5JVPbIUXNf/HY+ug5yspXxVcLwFBE6KRgFhWZQ=",
+        "owner": "TheInnerLight",
+        "repo": "hasura-ddn-cli-nix",
+        "rev": "7e0bda12c484f08d194377389191c1a58920b2b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "TheInnerLight",
+        "repo": "hasura-ddn-cli-nix",
+        "type": "github"
+      }
+    },
     "hercules-ci-effects": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -172,6 +209,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1723362943,
+        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1720542800,
         "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
         "owner": "NixOS",
@@ -193,9 +246,10 @@
         "crane": "crane",
         "flake-compat": "flake-compat",
         "graphql-engine-source": "graphql-engine-source",
-        "nixpkgs": "nixpkgs",
+        "hasura-ddn-cli": "hasura-ddn-cli",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay",
-        "systems": "systems"
+        "systems": "systems_2"
       }
     },
     "rust-overlay": {
@@ -219,6 +273,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -172,16 +172,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "dirtyRev": "deddc18875d3c691553f50b27dc9c249552fc545-dirty",
-        "dirtyShortRev": "deddc18-dirty",
-        "lastModified": 1724193024,
-        "narHash": "sha256-VU7JvulNSIfQoltHjaBhUD9uFOFiwshqi8h1Q0MM39Q=",
-        "type": "git",
-        "url": "file:///home/jesse/projects/hasura/hasura-ddn-cli-nix"
+        "lastModified": 1724197678,
+        "narHash": "sha256-yXS2S3nmHKur+pKgcg3imMz+xBKf211jUEHwtVbWhUk=",
+        "owner": "hasura",
+        "repo": "ddn-cli-nix",
+        "rev": "4a1279dbb2fe79f447cd409df710eee3a98fc16e",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "file:///home/jesse/projects/hasura/hasura-ddn-cli-nix"
+        "owner": "hasura",
+        "repo": "ddn-cli-nix",
+        "type": "github"
       }
     },
     "hercules-ci-effects": {

--- a/flake.lock
+++ b/flake.lock
@@ -172,17 +172,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1723539998,
-        "narHash": "sha256-9w9uF5JVPbIUXNf/HY+ug5yspXxVcLwFBE6KRgFhWZQ=",
-        "owner": "TheInnerLight",
-        "repo": "hasura-ddn-cli-nix",
-        "rev": "7e0bda12c484f08d194377389191c1a58920b2b1",
-        "type": "github"
+        "dirtyRev": "deddc18875d3c691553f50b27dc9c249552fc545-dirty",
+        "dirtyShortRev": "deddc18-dirty",
+        "lastModified": 1724193024,
+        "narHash": "sha256-VU7JvulNSIfQoltHjaBhUD9uFOFiwshqi8h1Q0MM39Q=",
+        "type": "git",
+        "url": "file:///home/jesse/projects/hasura/hasura-ddn-cli-nix"
       },
       "original": {
-        "owner": "TheInnerLight",
-        "repo": "hasura-ddn-cli-nix",
-        "type": "github"
+        "type": "git",
+        "url": "file:///home/jesse/projects/hasura/hasura-ddn-cli-nix"
       }
     },
     "hercules-ci-effects": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    hasura-ddn-cli.url = "github:TheInnerLight/hasura-ddn-cli-nix";
+
     # Allows selecting arbitrary Rust toolchain configurations by editing
     # `rust-toolchain.toml`
     rust-overlay = {
@@ -57,6 +59,7 @@
     { self
     , nixpkgs
     , crane
+    , hasura-ddn-cli
     , rust-overlay
     , advisory-db
     , arion
@@ -102,6 +105,8 @@
           # compiled for Linux but with the same architecture as `localSystem`.
           # This is useful for building Docker images on Mac developer machines.
           pkgsCross.linux = mkPkgsLinux final.buildPlatform.system;
+
+          ddn = hasura-ddn-cli.defaultPackage.${final.system};
         })
       ];
 
@@ -202,6 +207,7 @@
           nativeBuildInputs = with pkgs; [
             arion.packages.${pkgs.system}.default
             cargo-insta
+            ddn
             just
             mongosh
             pkg-config

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    hasura-ddn-cli.url = "github:TheInnerLight/hasura-ddn-cli-nix";
+    # hasura-ddn-cli.url = "github:TheInnerLight/hasura-ddn-cli-nix";
+    hasura-ddn-cli.url = "git+file:///home/jesse/projects/hasura/hasura-ddn-cli-nix";
 
     # Allows selecting arbitrary Rust toolchain configurations by editing
     # `rust-toolchain.toml`
@@ -72,6 +73,7 @@
       # packages or replace packages in that set.
       overlays = [
         (import rust-overlay)
+        hasura-ddn-cli.overlays.default
         (final: prev: {
           # What's the deal with `pkgsBuildHost`? It has to do with
           # cross-compiling.
@@ -105,8 +107,6 @@
           # compiled for Linux but with the same architecture as `localSystem`.
           # This is useful for building Docker images on Mac developer machines.
           pkgsCross.linux = mkPkgsLinux final.buildPlatform.system;
-
-          ddn = hasura-ddn-cli.defaultPackage.${final.system};
         })
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # hasura-ddn-cli.url = "github:TheInnerLight/hasura-ddn-cli-nix";
-    hasura-ddn-cli.url = "git+file:///home/jesse/projects/hasura/hasura-ddn-cli-nix";
+    hasura-ddn-cli.url = "github:hasura/ddn-cli-nix";
 
     # Allows selecting arbitrary Rust toolchain configurations by editing
     # `rust-toolchain.toml`
@@ -73,7 +72,6 @@
       # packages or replace packages in that set.
       overlays = [
         (import rust-overlay)
-        hasura-ddn-cli.overlays.default
         (final: prev: {
           # What's the deal with `pkgsBuildHost`? It has to do with
           # cross-compiling.
@@ -107,6 +105,8 @@
           # compiled for Linux but with the same architecture as `localSystem`.
           # This is useful for building Docker images on Mac developer machines.
           pkgsCross.linux = mkPkgsLinux final.buildPlatform.system;
+
+          ddn = hasura-ddn-cli.defaultPackage.${final.system};
         })
       ];
 


### PR DESCRIPTION
Since Extended JSON fields may contain any data users may reasonably want access to all comparison and aggregation operations. MongoDB is designed to accommodate functions that don't make sense on all values they are applied to. I included a native query that produces a collection of mixed data types, and some integration tests on that data.

I also updated the dev shell to pull the cli from the [nix flake](https://github.com/hasura/ddn-cli-nix) that @TheInnerLight helpfully set up.