### PR TITLE
ci: update rust-sec advisory db in every test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
       - name: run linter checks with clippy 🔨
         run: nix build .#checks.x86_64-linux.lint --print-build-logs
 
+      - name: update rust-sec advisory db before scanning for vulnerabilities
+        run: nix flake lock --update-input advisory-db
+
       - name: audit for reported security problems 🔨
         run: nix build .#checks.x86_64-linux.audit --print-build-logs
 


### PR DESCRIPTION
We have had a security vulnerability check on cargo dependencies in place for a long time. But it's necessary to update the advisory db to get the latest advisories. This change updates a github workflow to run the update on every CI test run.

I tested that the check catches problems by running a test with `gix-fs` installed at version 0.10.2. See https://rustsec.org/advisories/RUSTSEC-2024-0350.html