### PR TITLE
map `in` ndc operator to mongodb operator

### DIFF
--- a/crates/mongodb-agent-common/src/comparison_function.rs
+++ b/crates/mongodb-agent-common/src/comparison_function.rs
@@ -16,6 +16,8 @@ pub enum ComparisonFunction {
     Equal,
     NotEqual,
 
+    In,
+
     Regex,
     /// case-insensitive regex
     IRegex,
@@ -33,6 +35,7 @@ impl ComparisonFunction {
             C::GreaterThanOrEqual => "_gte",
             C::Equal => "_eq",
             C::NotEqual => "_neq",
+            C::In => "_in",
             C::Regex => "_regex",
             C::IRegex => "_iregex",
         }
@@ -45,6 +48,7 @@ impl ComparisonFunction {
             C::GreaterThan => "$gt",
             C::GreaterThanOrEqual => "$gte",
             C::Equal => "$eq",
+            C::In => "$in",
             C::NotEqual => "$ne",
             C::Regex => "$regex",
             C::IRegex => "$regex",

--- a/fixtures/hasura/test_cases/connector/connector.yaml
+++ b/fixtures/hasura/test_cases/connector/connector.yaml
@@ -1,5 +1,5 @@
 kind: Connector
-version: v1
+version: v2
 definition:
   name: test_cases
   subgraph: test_cases


### PR DESCRIPTION
This doesn't make the `in` operator usable to the end user, but it is a change we will need on the connector side when the engine gets supports for comparisons involving arrays.