### PR TITLE
accept queries that make array-to-scalar comparisons

### DIFF
--- a/crates/integration-tests/src/tests/filtering.rs
+++ b/crates/integration-tests/src/tests/filtering.rs
@@ -1,6 +1,7 @@
 use insta::assert_yaml_snapshot;
+use ndc_test_helpers::{binop, field, query, query_request, target, variable};
 
-use crate::graphql_query;
+use crate::{connector::Connector, graphql_query, run_connector_query};
 
 #[tokio::test]
 async fn filters_on_extended_json_using_string_comparison() -> anyhow::Result<()> {
@@ -52,3 +53,42 @@ async fn filters_by_comparisons_on_elements_of_array_field() -> anyhow::Result<(
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn filters_by_comparisons_on_elements_of_array_of_scalars() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+            query MyQuery {
+              movies(where: { cast: { _eq: "Albert Austin" } }) {
+                title
+                cast
+              }
+            }
+            "#
+        )
+        .run()
+        .await?
+    );
+    Ok(())
+}
+
+// #[tokio::test]
+// async fn filters_by_comparisons_on_elements_of_array_of_scalars_against_variable(
+// ) -> anyhow::Result<()> {
+//     assert_yaml_snapshot!(
+//         run_connector_query(
+//             Connector::SampleMflix,
+//             query_request()
+//                 .variables([[("cast_member", "Albert Austin")]])
+//                 .collection("movies")
+//                 .query(
+//                     query()
+//                         .predicate(binop("_eq", target!("cast"), variable!(cast_member)))
+//                         .fields([field!("title"), field!("cast")]),
+//                 )
+//         )
+//         .await?
+//     );
+//     Ok(())
+// }

--- a/crates/integration-tests/src/tests/filtering.rs
+++ b/crates/integration-tests/src/tests/filtering.rs
@@ -76,6 +76,17 @@ async fn filters_by_comparisons_on_elements_of_array_of_scalars() -> anyhow::Res
 #[tokio::test]
 async fn filters_by_comparisons_on_elements_of_array_of_scalars_against_variable(
 ) -> anyhow::Result<()> {
+    // Skip this test in MongoDB 5 because the example fails there. We're getting an error:
+    //
+    // > Kind: Command failed: Error code 5491300 (Location5491300): $documents' is not allowed in user requests, labels: {}
+    //
+    // This doesn't affect native queries that don't use the $documents stage.
+    if let Ok(image) = std::env::var("MONGODB_IMAGE") {
+        if image == "mongo:5" {
+            return Ok(());
+        }
+    }
+
     assert_yaml_snapshot!(
         run_connector_query(
             Connector::SampleMflix,

--- a/crates/integration-tests/src/tests/filtering.rs
+++ b/crates/integration-tests/src/tests/filtering.rs
@@ -73,22 +73,22 @@ async fn filters_by_comparisons_on_elements_of_array_of_scalars() -> anyhow::Res
     Ok(())
 }
 
-// #[tokio::test]
-// async fn filters_by_comparisons_on_elements_of_array_of_scalars_against_variable(
-// ) -> anyhow::Result<()> {
-//     assert_yaml_snapshot!(
-//         run_connector_query(
-//             Connector::SampleMflix,
-//             query_request()
-//                 .variables([[("cast_member", "Albert Austin")]])
-//                 .collection("movies")
-//                 .query(
-//                     query()
-//                         .predicate(binop("_eq", target!("cast"), variable!(cast_member)))
-//                         .fields([field!("title"), field!("cast")]),
-//                 )
-//         )
-//         .await?
-//     );
-//     Ok(())
-// }
+#[tokio::test]
+async fn filters_by_comparisons_on_elements_of_array_of_scalars_against_variable(
+) -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request()
+                .variables([[("cast_member", "Albert Austin")]])
+                .collection("movies")
+                .query(
+                    query()
+                        .predicate(binop("_eq", target!("cast"), variable!(cast_member)))
+                        .fields([field!("title"), field!("cast")]),
+                )
+        )
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_by_comparisons_on_elements_of_array_of_scalars.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_by_comparisons_on_elements_of_array_of_scalars.snap
@@ -1,0 +1,13 @@
+---
+source: crates/integration-tests/src/tests/filtering.rs
+expression: "graphql_query(r#\"\n            query MyQuery {\n              movies(where: { cast: { _eq: \"Albert Austin\" } }) {\n                title\n                cast\n              }\n            }\n            \"#).run().await?"
+---
+data:
+  movies:
+    - title: The Immigrant
+      cast:
+        - Charles Chaplin
+        - Edna Purviance
+        - Eric Campbell
+        - Albert Austin
+errors: ~

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_by_comparisons_on_elements_of_array_of_scalars_against_variable.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_by_comparisons_on_elements_of_array_of_scalars_against_variable.snap
@@ -1,0 +1,11 @@
+---
+source: crates/integration-tests/src/tests/filtering.rs
+expression: "run_connector_query(Connector::SampleMflix,\n            query_request().variables([[(\"cast_member\",\n                                            \"Albert Austin\")]]).collection(\"movies\").query(query().predicate(binop(\"_eq\",\n                            target!(\"cast\"),\n                            variable!(cast_member))).fields([field!(\"title\"),\n                            field!(\"cast\")]))).await?"
+---
+- rows:
+    - cast:
+        - Charles Chaplin
+        - Edna Purviance
+        - Eric Campbell
+        - Albert Austin
+      title: The Immigrant

--- a/crates/mongodb-agent-common/src/mongo_query_plan/mod.rs
+++ b/crates/mongodb-agent-common/src/mongo_query_plan/mod.rs
@@ -91,6 +91,9 @@ fn scalar_type_name(t: &Type) -> Option<&'static str> {
     match t {
         Type::Scalar(MongoScalarType::Bson(s)) => Some(s.graphql_name()),
         Type::Scalar(MongoScalarType::ExtendedJSON) => Some(EXTENDED_JSON_TYPE_NAME),
+        Type::ArrayOf(t) if matches!(**t, Type::Scalar(_) | Type::Nullable(_)) => {
+            scalar_type_name(t)
+        }
         Type::Nullable(t) => scalar_type_name(t),
         _ => None,
     }

--- a/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 use std::{collections::VecDeque, iter::once};
 
 use crate::{self as plan, type_annotated_field, ObjectType, QueryPlan, Scope};
-use helpers::find_nested_collection_type;
+use helpers::{find_nested_collection_type, value_type_in_possible_array_equality_comparison};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use ndc::{ExistsInCollection, QueryRequest};
@@ -516,7 +516,10 @@ fn plan_for_binary_comparison<T: QueryContext>(
         .context
         .find_comparison_operator(comparison_target.get_field_type(), &operator)?;
     let value_type = match operator_definition {
-        plan::ComparisonOperatorDefinition::Equal => comparison_target.get_field_type().clone(),
+        plan::ComparisonOperatorDefinition::Equal => {
+            let column_type = comparison_target.get_field_type().clone();
+            value_type_in_possible_array_equality_comparison(column_type)
+        }
         plan::ComparisonOperatorDefinition::In => {
             plan::Type::ArrayOf(Box::new(comparison_target.get_field_type().clone()))
         }

--- a/crates/ndc-query-plan/src/type_system.rs
+++ b/crates/ndc-query-plan/src/type_system.rs
@@ -24,6 +24,14 @@ impl<S> Type<S> {
             t => Type::Nullable(Box::new(t)),
         }
     }
+
+    pub fn is_array(&self) -> bool {
+        match self {
+            Type::ArrayOf(_) => true,
+            Type::Nullable(t) => t.is_array(),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
+++ b/fixtures/hasura/sample_mflix/metadata/models/Movies.hml
@@ -574,7 +574,11 @@ definition:
           booleanExpressionType: ObjectIdComparisonExp
         - fieldName: awards
           booleanExpressionType: MoviesAwardsComparisonExp
+        - fieldName: cast
+          booleanExpressionType: StringComparisonExp
         - fieldName: fullplot
+          booleanExpressionType: StringComparisonExp
+        - fieldName: genres
           booleanExpressionType: StringComparisonExp
         - fieldName: imdb
           booleanExpressionType: MoviesImdbComparisonExp


### PR DESCRIPTION
**Important**: this change allows filtering documents by scalar values inside arrays. But it does so using behavior of the GraphQL Engine that is currently undefined. We are in the process of defining that behavior - in a future Engine update to keep array-of-scalar comparisons working it will be necessary to configure additional metadata, and it will be necessary to upgrade the MongoDB connector at the same time. We expect that GraphQL APIs will remain the same before and after that Engine update.

MongoDB allows comparing array values to scalars. For example,

```ts
db.movies.aggregate([{ $match: { cast: { $eq: "Albert Austin" } } }])
```

The condition passes if any array element passes the comparison.

Currently the GraphQL Engine does not have a way to filter by scalar values in array fields. But it does allow declaring that array fields can be used in scalar comparisons. So with some connector updates this allows us to unblock users who need to be able to filter by array values.

This PR updates the connector to:
- find a scalar comparison operator definition for equality corresponding to the scalar type of array elements in the given column
- infer the appropriate scalar type for the comparison value instead of assuming that the value type in an equality comparison is the same as the column type

Some notes on the implementation and implications:

The connector needs to know operand types for comparisons. The left operand is always a database
document field so we can get that type from the schema. But if the right operand is an inline value
or a variable we have to infer its type from context.

Normally we assume that the right operand of Equal is the same type as the left operand. But since
MongoDB allows comparing arrays to scalar values then in case that is desired then instead of
inferring an array type for the right operand to match the left, we want the type of the right
operand to be the array element type of the left operand. That brings up the question: how do we
know if the user's intention is to make an array-to-scalar comparison, or an array-to-array
comparison? Since we don't support array-to-array comparisons yet for simplicity this PR assumes
that if the field has an array type, the right-operand type is a scalar type.

When we do support array-to-array comparisons we have two options.

1. inspect inline values or variable values given for the right operand, and assume an
  array-to-scalar comparison only if all of those are non-array values
2. or get the GraphQL Engine to include a type with `ComparisonValue` in which case we can
  use that as the right-operand type

It is important that queries behave the same when given an inline value or variables. So we can't
just check inline values, and punt on variables. It will require a little more work to thread
variables through the code to the point they are needed for this check so I haven't done that just
yet.

**Edit:** We have plans to update the NDC spec to get the necessary type information from the Engine in a future version.
