### PR TITLE
fix selecting nested field with name that begins with dollar sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This changelog documents the changes between release versions.
 
 ## [Unreleased]
 
+### Added
+
+### Fixed
+
+- Selecting nested fields with names that begin with a dollar sign ([#108](https://github.com/hasura/ndc-mongodb/pull/108))
+
+### Changed
+
 ## [1.2.0] - 2024-09-12
 
 ### Added
@@ -116,10 +124,6 @@ definition:
   graphql:
     typeName: InstitutionStaffComparisonExp
 ```
-
-### Fixed
-
-### Changed
 
 ## [1.1.0] - 2024-08-16
 

--- a/crates/integration-tests/src/tests/basic.rs
+++ b/crates/integration-tests/src/tests/basic.rs
@@ -77,7 +77,7 @@ async fn selects_nested_field_with_dollar_sign_in_name() -> anyhow::Result<()> {
         graphql_query(
             r#"
             query {
-              testCases_nestedFieldWithDollar {
+              testCases_nestedFieldWithDollar(order_by: { configuration: Asc }) {
                 configuration {
                   schema
                 }

--- a/crates/integration-tests/src/tests/basic.rs
+++ b/crates/integration-tests/src/tests/basic.rs
@@ -70,3 +70,23 @@ async fn selects_array_within_array() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn selects_nested_field_with_dollar_sign_in_name() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+            query {
+              testCases_nestedFieldWithDollar {
+                configuration {
+                  schema
+                }
+              }
+            }
+            "#
+        )
+        .run()
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__basic__selects_nested_field_with_dollar_sign_in_name.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__basic__selects_nested_field_with_dollar_sign_in_name.snap
@@ -1,0 +1,13 @@
+---
+source: crates/integration-tests/src/tests/basic.rs
+expression: "graphql_query(r#\"\n            query {\n              testCases_nestedFieldWithDollar {\n                configuration {\n                  schema\n                }\n              }\n            }\n            \"#).run().await?"
+---
+data:
+  testCases_nestedFieldWithDollar:
+    - configuration:
+        schema: ~
+    - configuration:
+        schema: schema3
+    - configuration:
+        schema: schema1
+errors: ~

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__basic__selects_nested_field_with_dollar_sign_in_name.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__basic__selects_nested_field_with_dollar_sign_in_name.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/integration-tests/src/tests/basic.rs
-expression: "graphql_query(r#\"\n            query {\n              testCases_nestedFieldWithDollar {\n                configuration {\n                  schema\n                }\n              }\n            }\n            \"#).run().await?"
+expression: "graphql_query(r#\"\n            query {\n              testCases_nestedFieldWithDollar(order_by: { configuration: Asc }) {\n                configuration {\n                  schema\n                }\n              }\n            }\n            \"#).run().await?"
 ---
 data:
   testCases_nestedFieldWithDollar:
     - configuration:
         schema: ~
     - configuration:
-        schema: schema3
-    - configuration:
         schema: schema1
+    - configuration:
+        schema: schema3
 errors: ~

--- a/crates/mongodb-agent-common/src/mongodb/selection.rs
+++ b/crates/mongodb-agent-common/src/mongodb/selection.rs
@@ -1,11 +1,13 @@
 use indexmap::IndexMap;
 use mongodb::bson::{self, doc, Bson, Document};
+use ndc_models::FieldName;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     interface_types::MongoAgentError,
     mongo_query_plan::{Field, NestedArray, NestedField, NestedObject, QueryPlan},
     mongodb::sanitize::get_field,
+    query::column_ref::ColumnRef,
 };
 
 /// Wraps a BSON document that represents a MongoDB "expression" that constructs a document based
@@ -32,51 +34,50 @@ impl Selection {
         } else {
             &empty_map
         };
-        let doc = from_query_request_helper(&[], fields)?;
+        let doc = from_query_request_helper(None, fields)?;
         Ok(Selection(doc))
     }
 }
 
 fn from_query_request_helper(
-    parent_columns: &[&str],
+    parent: Option<ColumnRef<'_>>,
     field_selection: &IndexMap<ndc_models::FieldName, Field>,
 ) -> Result<Document, MongoAgentError> {
     field_selection
         .iter()
-        .map(|(key, value)| Ok((key.to_string(), selection_for_field(parent_columns, value)?)))
+        .map(|(key, value)| Ok((key.to_string(), selection_for_field(parent.clone(), value)?)))
         .collect()
 }
 
 /// Wraps column reference with an `$isNull` check. That catches cases where a field is missing
 /// from a document, and substitutes a concrete null value. Otherwise the field would be omitted
 /// from query results which leads to an error in the engine.
-fn value_or_null(col_path: String) -> Bson {
-    doc! { "$ifNull": [col_path, Bson::Null] }.into()
+fn value_or_null(value: Bson) -> Bson {
+    doc! { "$ifNull": [value, Bson::Null] }.into()
 }
 
-fn selection_for_field(parent_columns: &[&str], field: &Field) -> Result<Bson, MongoAgentError> {
+fn selection_for_field(
+    parent: Option<ColumnRef<'_>>,
+    field: &Field,
+) -> Result<Bson, MongoAgentError> {
     match field {
         Field::Column {
             column,
             fields: None,
             ..
         } => {
-            let col_path = match parent_columns {
-                [] => format!("${column}"),
-                _ => format!("${}.{}", parent_columns.join("."), column),
-            };
-            let bson_col_path = value_or_null(col_path);
-            Ok(bson_col_path)
+            let col_ref = nested_column_reference(parent, column);
+            let col_ref_or_null = value_or_null(col_ref.into_aggregate_expression());
+            Ok(col_ref_or_null)
         }
         Field::Column {
             column,
             fields: Some(NestedField::Object(NestedObject { fields })),
             ..
         } => {
-            let nested_parent_columns = append_to_path(parent_columns, column.as_str());
-            let nested_parent_col_path = format!("${}", nested_parent_columns.join("."));
-            let nested_selection = from_query_request_helper(&nested_parent_columns, fields)?;
-            Ok(doc! {"$cond": {"if": nested_parent_col_path, "then": nested_selection, "else": Bson::Null}}.into())
+            let col_ref = nested_column_reference(parent, column);
+            let nested_selection = from_query_request_helper(Some(col_ref.clone()), fields)?;
+            Ok(doc! {"$cond": {"if": col_ref.into_aggregate_expression(), "then": nested_selection, "else": Bson::Null}}.into())
         }
         Field::Column {
             column,
@@ -85,11 +86,7 @@ fn selection_for_field(parent_columns: &[&str], field: &Field) -> Result<Bson, M
                     fields: nested_field,
                 })),
             ..
-        } => selection_for_array(
-            &append_to_path(parent_columns, column.as_str()),
-            nested_field,
-            0,
-        ),
+        } => selection_for_array(nested_column_reference(parent, column), nested_field, 0),
         Field::Relationship {
             relationship,
             aggregates,
@@ -161,32 +158,42 @@ fn selection_for_field(parent_columns: &[&str], field: &Field) -> Result<Bson, M
 }
 
 fn selection_for_array(
-    parent_columns: &[&str],
+    parent: ColumnRef<'_>,
     field: &NestedField,
     array_nesting_level: usize,
 ) -> Result<Bson, MongoAgentError> {
     match field {
         NestedField::Object(NestedObject { fields }) => {
-            let nested_parent_col_path = format!("${}", parent_columns.join("."));
-            let mut nested_selection = from_query_request_helper(&["$this"], fields)?;
+            let mut nested_selection =
+                from_query_request_helper(Some(ColumnRef::variable("this")), fields)?;
             for _ in 0..array_nesting_level {
                 nested_selection = doc! {"$map": {"input": "$$this", "in": nested_selection}}
             }
-            let map_expression =
-                doc! {"$map": {"input": &nested_parent_col_path, "in": nested_selection}};
-            Ok(doc! {"$cond": {"if": &nested_parent_col_path, "then": map_expression, "else": Bson::Null}}.into())
+            let map_expression = doc! {"$map": {"input": parent.clone().into_aggregate_expression(), "in": nested_selection}};
+            Ok(doc! {"$cond": {"if": parent.into_aggregate_expression(), "then": map_expression, "else": Bson::Null}}.into())
         }
         NestedField::Array(NestedArray {
             fields: nested_field,
-        }) => selection_for_array(parent_columns, nested_field, array_nesting_level + 1),
+        }) => selection_for_array(parent, nested_field, array_nesting_level + 1),
     }
 }
-fn append_to_path<'a, 'b, 'c>(parent_columns: &'a [&'b str], column: &'c str) -> Vec<&'c str>
-where
-    'b: 'c,
-{
-    parent_columns.iter().copied().chain(Some(column)).collect()
+
+fn nested_column_reference<'a>(
+    parent: Option<ColumnRef<'a>>,
+    column: &'a FieldName,
+) -> ColumnRef<'a> {
+    match parent {
+        Some(parent) => parent.into_nested_field(column),
+        None => ColumnRef::from_field_path([column]),
+    }
 }
+
+// fn append_to_path<'a, 'b, 'c, T>(parent_columns: &'a [&'b T], column: &'c T) -> Vec<&'c T>
+// where
+//     'b: 'c,
+// {
+//     parent_columns.iter().copied().chain(Some(column)).collect()
+// }
 
 /// The extend implementation provides a shallow merge.
 impl Extend<(String, Bson)> for Selection {

--- a/crates/mongodb-agent-common/src/mongodb/selection.rs
+++ b/crates/mongodb-agent-common/src/mongodb/selection.rs
@@ -188,13 +188,6 @@ fn nested_column_reference<'a>(
     }
 }
 
-// fn append_to_path<'a, 'b, 'c, T>(parent_columns: &'a [&'b T], column: &'c T) -> Vec<&'c T>
-// where
-//     'b: 'c,
-// {
-//     parent_columns.iter().copied().chain(Some(column)).collect()
-// }
-
 /// The extend implementation provides a shallow merge.
 impl Extend<(String, Bson)> for Selection {
     fn extend<T: IntoIterator<Item = (String, Bson)>>(&mut self, iter: T) {

--- a/crates/mongodb-agent-common/src/query/mod.rs
+++ b/crates/mongodb-agent-common/src/query/mod.rs
@@ -1,4 +1,4 @@
-mod column_ref;
+pub mod column_ref;
 mod constants;
 mod execute_query_request;
 mod foreach;

--- a/fixtures/hasura/test_cases/connector/schema/nested_field_with_dollar.json
+++ b/fixtures/hasura/test_cases/connector/schema/nested_field_with_dollar.json
@@ -1,0 +1,35 @@
+{
+  "name": "nested_field_with_dollar",
+  "collections": {
+    "nested_field_with_dollar": {
+      "type": "nested_field_with_dollar"
+    }
+  },
+  "objectTypes": {
+    "nested_field_with_dollar": {
+      "fields": {
+        "_id": {
+          "type": {
+            "scalar": "objectId"
+          }
+        },
+        "configuration": {
+          "type": {
+            "object": "nested_field_with_dollar_configuration"
+          }
+        }
+      }
+    },
+    "nested_field_with_dollar_configuration": {
+      "fields": {
+        "$schema": {
+          "type": {
+            "nullable": {
+              "scalar": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fixtures/hasura/test_cases/metadata/models/NestedFieldWithDollar.hml
+++ b/fixtures/hasura/test_cases/metadata/models/NestedFieldWithDollar.hml
@@ -1,0 +1,121 @@
+---
+kind: ObjectType
+version: v1
+definition:
+  name: NestedFieldWithDollarConfiguration
+  fields:
+    - name: schema
+      type: String
+  graphql:
+    typeName: TestCases_NestedFieldWithDollarConfiguration
+    inputTypeName: TestCases_NestedFieldWithDollarConfigurationInput
+  dataConnectorTypeMapping:
+    - dataConnectorName: test_cases
+      dataConnectorObjectType: nested_field_with_dollar_configuration
+      fieldMapping:
+        schema:
+          column:
+            name: $schema
+
+---
+kind: TypePermissions
+version: v1
+definition:
+  typeName: NestedFieldWithDollarConfiguration
+  permissions:
+    - role: admin
+      output:
+        allowedFields:
+          - schema
+
+---
+kind: ObjectType
+version: v1
+definition:
+  name: NestedFieldWithDollar
+  fields:
+    - name: id
+      type: ObjectId!
+    - name: configuration
+      type: NestedFieldWithDollarConfiguration!
+  graphql:
+    typeName: TestCases_NestedFieldWithDollar
+    inputTypeName: TestCases_NestedFieldWithDollarInput
+  dataConnectorTypeMapping:
+    - dataConnectorName: test_cases
+      dataConnectorObjectType: nested_field_with_dollar
+      fieldMapping:
+        id:
+          column:
+            name: _id
+        configuration:
+          column:
+            name: configuration
+
+---
+kind: TypePermissions
+version: v1
+definition:
+  typeName: NestedFieldWithDollar
+  permissions:
+    - role: admin
+      output:
+        allowedFields:
+          - id
+          - configuration
+
+---
+kind: BooleanExpressionType
+version: v1
+definition:
+  name: NestedFieldWithDollarComparisonExp
+  operand:
+    object:
+      type: NestedFieldWithDollar
+      comparableFields:
+        - fieldName: id
+          booleanExpressionType: ObjectIdComparisonExp
+      comparableRelationships: []
+  logicalOperators:
+    enable: true
+  isNull:
+    enable: true
+  graphql:
+    typeName: TestCases_NestedFieldWithDollarComparisonExp
+
+---
+kind: Model
+version: v1
+definition:
+  name: NestedFieldWithDollar
+  objectType: NestedFieldWithDollar
+  source:
+    dataConnectorName: test_cases
+    collection: nested_field_with_dollar
+  filterExpressionType: NestedFieldWithDollarComparisonExp
+  orderableFields:
+    - fieldName: id
+      orderByDirections:
+        enableAll: true
+    - fieldName: configuration
+      orderByDirections:
+        enableAll: true
+  graphql:
+    selectMany:
+      queryRootField: testCases_nestedFieldWithDollar
+    selectUniques:
+      - queryRootField: testCases_nestedFieldWithDollarById
+        uniqueIdentifier:
+          - id
+    orderByExpressionType: TestCases_NestedFieldWithDollarOrderBy
+
+---
+kind: ModelPermissions
+version: v1
+definition:
+  modelName: NestedFieldWithDollar
+  permissions:
+    - role: admin
+      select:
+        filter: null
+

--- a/fixtures/hasura/test_cases/metadata/test_cases.hml
+++ b/fixtures/hasura/test_cases/metadata/test_cases.hml
@@ -241,6 +241,11 @@ definition:
               argument_type:
                 type: named
                 name: ExtendedJSON
+            _in:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
             _iregex:
               type: custom
               argument_type:
@@ -596,6 +601,24 @@ definition:
               type:
                 type: named
                 name: String
+        nested_field_with_dollar:
+          fields:
+            _id:
+              type:
+                type: named
+                name: ObjectId
+            configuration:
+              type:
+                type: named
+                name: nested_field_with_dollar_configuration
+        nested_field_with_dollar_configuration:
+          fields:
+            $schema:
+              type:
+                type: nullable
+                underlying_type:
+                  type: named
+                  name: String
         weird_field_names:
           fields:
             $invalid.name:
@@ -632,6 +655,14 @@ definition:
           type: nested_collection
           uniqueness_constraints:
             nested_collection_id:
+              unique_columns:
+                - _id
+          foreign_keys: {}
+        - name: nested_field_with_dollar
+          arguments: {}
+          type: nested_field_with_dollar
+          uniqueness_constraints:
+            nested_field_with_dollar_id:
               unique_columns:
                 - _id
           foreign_keys: {}

--- a/fixtures/mongodb/test_cases/import.sh
+++ b/fixtures/mongodb/test_cases/import.sh
@@ -13,5 +13,6 @@ FIXTURES=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "📡 Importing test case data..."
 mongoimport --db test_cases --collection weird_field_names --file "$FIXTURES"/weird_field_names.json
 mongoimport --db test_cases --collection nested_collection --file "$FIXTURES"/nested_collection.json
+mongoimport --db test_cases --collection nested_field_with_dollar --file "$FIXTURES"/nested_field_with_dollar.json
 echo "✅ test case data imported..."
 

--- a/fixtures/mongodb/test_cases/nested_field_with_dollar.json
+++ b/fixtures/mongodb/test_cases/nested_field_with_dollar.json
@@ -1,0 +1,3 @@
+{ "configuration": { "$schema": "schema1" } }
+{ "configuration": { "$schema": null } }
+{ "configuration": { "$schema": "schema3" } }


### PR DESCRIPTION
This PR updates the logic for building selection documents for the `$replaceWith` pipeline stage to be more rigorous. It uses an expanded `ColumnRef` enum to keep track of whether the selected reference has a name that needs to be escaped, is a variable, etc.