### PR TITLE
ignore existing configuration when regenerating native query

### DIFF
--- a/crates/cli/src/native_query/type_solver/simplify.rs
+++ b/crates/cli/src/native_query/type_solver/simplify.rs
@@ -53,9 +53,11 @@ fn simplify_constraint_pair(
     b: TypeConstraint,
 ) -> Simplified<TypeConstraint> {
     match (a, b) {
-        (C::ExtendedJSON, _) | (_, C::ExtendedJSON) => Ok(C::ExtendedJSON),
+        (C::ExtendedJSON, _) | (_, C::ExtendedJSON) => Ok(C::ExtendedJSON), // TODO: Do we want this in contravariant case?
         (C::Scalar(a), C::Scalar(b)) => solve_scalar(variance, a, b),
 
+        // TODO: We need to make sure we aren't putting multiple layers of Nullable on constraints
+        // - if a and b have mismatched levels of Nullable they won't unify
         (C::Nullable(a), C::Nullable(b)) => {
             simplify_constraint_pair(configuration, object_type_constraints, variance, *a, *b)
                 .map(|constraint| C::Nullable(Box::new(constraint)))

--- a/crates/configuration/src/lib.rs
+++ b/crates/configuration/src/lib.rs
@@ -11,8 +11,8 @@ pub use crate::configuration::Configuration;
 pub use crate::directory::get_config_file_changed;
 pub use crate::directory::list_existing_schemas;
 pub use crate::directory::parse_configuration_options_file;
-pub use crate::directory::read_directory;
 pub use crate::directory::write_schema_directory;
+pub use crate::directory::{read_directory, read_directory_with_ignored_configs};
 pub use crate::directory::{
     CONFIGURATION_OPTIONS_BASENAME, CONFIGURATION_OPTIONS_METADATA, NATIVE_MUTATIONS_DIRNAME,
     NATIVE_QUERIES_DIRNAME, SCHEMA_DIRNAME,

--- a/crates/configuration/src/native_query.rs
+++ b/crates/configuration/src/native_query.rs
@@ -15,7 +15,7 @@ use crate::serialized;
 /// Note: this type excludes `name` and `object_types` from the serialized type. Object types are
 /// intended to be merged into one big map so should not be accessed through values of this type.
 /// Native query values are stored in maps so names should be taken from map keys.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct NativeQuery {
     pub representation: NativeQueryRepresentation,
     pub input_collection: Option<ndc::CollectionName>,

--- a/crates/configuration/src/serialized/native_query.rs
+++ b/crates/configuration/src/serialized/native_query.rs
@@ -35,6 +35,7 @@ pub struct NativeQuery {
 
     /// Use `input_collection` when you want to start an aggregation pipeline off of the specified
     /// `input_collection` db.<input_collection>.aggregate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input_collection: Option<ndc_models::CollectionName>,
 
     /// Arguments to be supplied for each query invocation. These will be available to the given


### PR DESCRIPTION
This is important for generating object types with the same name when making changes to a native query. That minimizes metadata changes.