### PR TITLE
add $in and $nin operators to connector schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog documents the changes between release versions.
 
 ### Added
 
-- Adds `_in` and `_nin` operators
+- Adds `_in` and `_nin` operators ([#122](https://github.com/hasura/ndc-mongodb/pull/122))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog documents the changes between release versions.
 
 ### Added
 
+- Adds `_in` and `_nin` operators
+
 ### Changed
 
 - **BREAKING:** If `configuration.json` cannot be parsed the connector will fail to start. This change also prohibits unknown keys in that file. These changes will help to prevent typos configuration being silently ignored. ([#115](https://github.com/hasura/ndc-mongodb/pull/115))
@@ -14,6 +16,26 @@ This changelog documents the changes between release versions.
 
 - Fixes for filtering by complex predicate that references variables, or field names that require escaping ([#111](https://github.com/hasura/ndc-mongodb/pull/111))
 - Escape names if necessary instead of failing when joining relationship on field names with special characters ([#113](https://github.com/hasura/ndc-mongodb/pull/113))
+
+#### `_in` and `_nin`
+
+These operators compare document values for equality against a given set of
+options. `_in` matches documents where one of the given values matches, `_nin` matches
+documents where none of the given values matches. For example this query selects
+movies that are rated either "G" or "TV-G":
+
+```graphql
+query {
+  movies(
+    where: { rated: { _in: ["G", "TV-G"] } }
+    order_by: { id: Asc }
+    limit: 5
+  ) {
+    title
+    rated
+  }
+}
+```
 
 ## [1.3.0] - 2024-10-01
 

--- a/crates/integration-tests/src/tests/filtering.rs
+++ b/crates/integration-tests/src/tests/filtering.rs
@@ -4,6 +4,29 @@ use ndc_test_helpers::{binop, field, query, query_request, target, variable};
 use crate::{connector::Connector, graphql_query, run_connector_query};
 
 #[tokio::test]
+async fn filters_using_in_operator() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+            query {
+              movies(
+                where: { rated: { _in: ["G", "TV-G"] } }
+                order_by: { id: Asc }
+                limit: 5
+              ) {
+                title
+                rated
+              }
+            }
+            "#
+        )
+        .run()
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn filters_on_extended_json_using_string_comparison() -> anyhow::Result<()> {
     assert_yaml_snapshot!(
         graphql_query(

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_using_in_operator.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__filtering__filters_using_in_operator.snap
@@ -1,0 +1,17 @@
+---
+source: crates/integration-tests/src/tests/filtering.rs
+expression: "graphql_query(r#\"\n            query {\n              movies(\n                where: { rated: { _in: [\"G\", \"TV-G\"] } }\n                order_by: { id: Asc }\n                limit: 5\n              ) {\n                title\n                rated\n              }\n            }\n            \"#).run().await?"
+---
+data:
+  movies:
+    - title: The Great Train Robbery
+      rated: TV-G
+    - title: A Corner in Wheat
+      rated: G
+    - title: From Hand to Mouth
+      rated: TV-G
+    - title: One Week
+      rated: TV-G
+    - title: The Devil to Pay!
+      rated: TV-G
+errors: ~

--- a/crates/mongodb-agent-common/src/comparison_function.rs
+++ b/crates/mongodb-agent-common/src/comparison_function.rs
@@ -17,6 +17,7 @@ pub enum ComparisonFunction {
     NotEqual,
 
     In,
+    NotIn,
 
     Regex,
     /// case-insensitive regex
@@ -36,6 +37,7 @@ impl ComparisonFunction {
             C::Equal => "_eq",
             C::NotEqual => "_neq",
             C::In => "_in",
+            C::NotIn => "_nin",
             C::Regex => "_regex",
             C::IRegex => "_iregex",
         }
@@ -49,6 +51,7 @@ impl ComparisonFunction {
             C::GreaterThanOrEqual => "$gte",
             C::Equal => "$eq",
             C::In => "$in",
+            C::NotIn => "$nin",
             C::NotEqual => "$ne",
             C::Regex => "$regex",
             C::IRegex => "$regex",

--- a/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
+++ b/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
@@ -116,6 +116,7 @@ fn bson_comparison_operators(
             let fn_name = comparison_fn.graphql_name().into();
             match comparison_fn {
                 ComparisonFunction::Equal => (fn_name, ComparisonOperatorDefinition::Equal),
+                ComparisonFunction::In => (fn_name, ComparisonOperatorDefinition::In),
                 _ => (
                     fn_name,
                     ComparisonOperatorDefinition::Custom { argument_type },

--- a/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
+++ b/crates/mongodb-agent-common/src/scalar_types_capabilities.rs
@@ -112,15 +112,13 @@ fn bson_comparison_operators(
     bson_scalar_type: BsonScalarType,
 ) -> BTreeMap<ComparisonOperatorName, ComparisonOperatorDefinition> {
     comparison_operators(bson_scalar_type)
-        .map(|(comparison_fn, arg_type)| {
+        .map(|(comparison_fn, argument_type)| {
             let fn_name = comparison_fn.graphql_name().into();
             match comparison_fn {
                 ComparisonFunction::Equal => (fn_name, ComparisonOperatorDefinition::Equal),
                 _ => (
                     fn_name,
-                    ComparisonOperatorDefinition::Custom {
-                        argument_type: bson_to_named_type(arg_type),
-                    },
+                    ComparisonOperatorDefinition::Custom { argument_type },
                 ),
             }
         })
@@ -167,10 +165,27 @@ pub fn aggregate_functions(
 
 pub fn comparison_operators(
     scalar_type: BsonScalarType,
-) -> impl Iterator<Item = (ComparisonFunction, BsonScalarType)> {
+) -> impl Iterator<Item = (ComparisonFunction, Type)> {
     iter_if(
         scalar_type.is_comparable(),
-        [(C::Equal, scalar_type), (C::NotEqual, scalar_type)].into_iter(),
+        [
+            (C::Equal, bson_to_named_type(scalar_type)),
+            (C::NotEqual, bson_to_named_type(scalar_type)),
+            (
+                C::In,
+                Type::Array {
+                    element_type: Box::new(bson_to_named_type(scalar_type)),
+                },
+            ),
+            (
+                C::NotIn,
+                Type::Array {
+                    element_type: Box::new(bson_to_named_type(scalar_type)),
+                },
+            ),
+            (C::NotEqual, bson_to_named_type(scalar_type)),
+        ]
+        .into_iter(),
     )
     .chain(iter_if(
         scalar_type.is_orderable(),
@@ -181,11 +196,17 @@ pub fn comparison_operators(
             C::GreaterThanOrEqual,
         ]
         .into_iter()
-        .map(move |op| (op, scalar_type)),
+        .map(move |op| (op, bson_to_named_type(scalar_type))),
     ))
     .chain(match scalar_type {
-        S::String => Box::new([(C::Regex, S::String), (C::IRegex, S::String)].into_iter()),
-        _ => Box::new(std::iter::empty()) as Box<dyn Iterator<Item = (C, S)>>,
+        S::String => Box::new(
+            [
+                (C::Regex, bson_to_named_type(S::String)),
+                (C::IRegex, bson_to_named_type(S::String)),
+            ]
+            .into_iter(),
+        ),
+        _ => Box::new(std::iter::empty()) as Box<dyn Iterator<Item = (C, Type)>>,
     })
 }
 

--- a/fixtures/hasura/chinook/metadata/chinook.hml
+++ b/fixtures/hasura/chinook/metadata/chinook.hml
@@ -21,11 +21,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: BinData
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
         Bool:
           representation:
             type: boolean
@@ -37,11 +51,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Bool
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
         Date:
           representation:
             type: timestamp
@@ -71,6 +99,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
             _lt:
               type: custom
               argument_type:
@@ -86,6 +121,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
         DbPointer:
           aggregate_functions:
             count:
@@ -95,11 +137,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: DbPointer
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
         Decimal:
           representation:
             type: bigdecimal
@@ -137,6 +193,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
             _lt:
               type: custom
               argument_type:
@@ -152,6 +215,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
         Double:
           representation:
             type: float64
@@ -189,6 +259,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
             _lt:
               type: custom
               argument_type:
@@ -204,6 +281,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
         ExtendedJSON:
           representation:
             type: json
@@ -241,6 +325,11 @@ definition:
               argument_type:
                 type: named
                 name: ExtendedJSON
+            _in:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
             _iregex:
               type: custom
               argument_type:
@@ -257,6 +346,11 @@ definition:
                 type: named
                 name: ExtendedJSON
             _neq:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _nin:
               type: custom
               argument_type:
                 type: named
@@ -303,6 +397,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
             _lt:
               type: custom
               argument_type:
@@ -318,6 +419,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
         Javascript:
           aggregate_functions:
             count:
@@ -369,6 +477,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
             _lt:
               type: custom
               argument_type:
@@ -384,6 +499,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
         MaxKey:
           aggregate_functions:
             count:
@@ -393,11 +515,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MaxKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
         MinKey:
           aggregate_functions:
             count:
@@ -407,11 +543,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MinKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
         "Null":
           aggregate_functions:
             count:
@@ -421,11 +571,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: "Null"
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
         ObjectId:
           representation:
             type: string
@@ -437,11 +601,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: ObjectId
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
         Regex:
           aggregate_functions:
             count:
@@ -478,6 +656,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _iregex:
               type: custom
               argument_type:
@@ -498,6 +683,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _regex:
               type: custom
               argument_type:
@@ -512,11 +704,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Symbol
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
         Timestamp:
           aggregate_functions:
             count:
@@ -544,6 +750,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
             _lt:
               type: custom
               argument_type:
@@ -559,6 +772,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
         Undefined:
           aggregate_functions:
             count:
@@ -568,11 +788,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Undefined
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
       object_types:
         Album:
           description: Object type for collection Album
@@ -1146,7 +1380,7 @@ definition:
             type: named
             name: InsertArtist
     capabilities:
-      version: 0.1.5
+      version: 0.1.6
       capabilities:
         query:
           aggregates: {}

--- a/fixtures/hasura/chinook/metadata/chinook.hml
+++ b/fixtures/hasura/chinook/metadata/chinook.hml
@@ -22,12 +22,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: BinData
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -52,12 +47,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Bool
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -100,12 +90,7 @@ definition:
                 type: named
                 name: Date
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Date
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -138,12 +123,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: DbPointer
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -194,12 +174,7 @@ definition:
                 type: named
                 name: Decimal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Decimal
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -260,12 +235,7 @@ definition:
                 type: named
                 name: Double
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Double
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -398,12 +368,7 @@ definition:
                 type: named
                 name: Int
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Int
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -478,12 +443,7 @@ definition:
                 type: named
                 name: Long
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Long
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -516,12 +476,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MaxKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -544,12 +499,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MinKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -572,12 +522,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: "Null"
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -602,12 +547,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: ObjectId
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -657,12 +597,7 @@ definition:
                 type: named
                 name: String
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: String
+              type: in
             _iregex:
               type: custom
               argument_type:
@@ -705,12 +640,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Symbol
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -751,12 +681,7 @@ definition:
                 type: named
                 name: Timestamp
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Timestamp
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -789,12 +714,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Undefined
+              type: in
             _neq:
               type: custom
               argument_type:

--- a/fixtures/hasura/common/metadata/scalar-types/Date.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Date.hml
@@ -43,6 +43,10 @@ definition:
           argumentType: Date
         - name: _neq
           argumentType: Date
+        - name: _in
+          argumentType: "[Date!]!"
+        - name: _nin
+          argumentType: "[Date!]!"
         - name: _gt
           argumentType: Date
         - name: _gte
@@ -57,6 +61,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -66,6 +72,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -75,6 +83,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Decimal.hml
@@ -43,6 +43,10 @@ definition:
           argumentType: Decimal
         - name: _neq
           argumentType: Decimal
+        - name: _in
+          argumentType: "[Decimal!]!"
+        - name: _nin
+          argumentType: "[Decimal!]!"
         - name: _gt
           argumentType: Decimal
         - name: _gte
@@ -57,6 +61,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -66,6 +72,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -75,6 +83,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/common/metadata/scalar-types/Double.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Double.hml
@@ -35,6 +35,10 @@ definition:
           argumentType: Float
         - name: _neq
           argumentType: Float
+        - name: _in
+          argumentType: "[Float!]!"
+        - name: _nin
+          argumentType: "[Float!]!"
         - name: _gt
           argumentType: Float
         - name: _gte
@@ -49,6 +53,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -58,6 +64,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -67,6 +75,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/common/metadata/scalar-types/ExtendedJSON.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/ExtendedJSON.hml
@@ -43,6 +43,10 @@ definition:
           argumentType: ExtendedJSON
         - name: _neq
           argumentType: ExtendedJSON
+        - name: _in
+          argumentType: "[ExtendedJSON!]!"
+        - name: _nin
+          argumentType: "[ExtendedJSON!]!"
         - name: _gt
           argumentType: ExtendedJSON
         - name: _gte
@@ -61,6 +65,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -72,6 +78,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -83,6 +91,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/common/metadata/scalar-types/Int.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/Int.hml
@@ -35,6 +35,10 @@ definition:
           argumentType: Int
         - name: _neq
           argumentType: Int
+        - name: _in
+          argumentType: "[Int!]!"
+        - name: _nin
+          argumentType: "[Int!]!"
         - name: _gt
           argumentType: Int
         - name: _gte
@@ -49,6 +53,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -58,6 +64,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -67,6 +75,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/common/metadata/scalar-types/ObjectId.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/ObjectId.hml
@@ -43,22 +43,32 @@ definition:
           argumentType: ObjectId
         - name: _neq
           argumentType: ObjectId
+        - name: _in
+          argumentType: "[ObjectId!]!"
+        - name: _nin
+          argumentType: "[ObjectId!]!"
       dataConnectorOperatorMapping:
         - dataConnectorName: chinook
           dataConnectorScalarType: ObjectId
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
         - dataConnectorName: sample_mflix
           dataConnectorScalarType: ObjectId
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
         - dataConnectorName: test_cases
           dataConnectorScalarType: ObjectId
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
   logicalOperators:
     enable: true
   isNull:

--- a/fixtures/hasura/common/metadata/scalar-types/String.hml
+++ b/fixtures/hasura/common/metadata/scalar-types/String.hml
@@ -35,6 +35,10 @@ definition:
           argumentType: String
         - name: _neq
           argumentType: String
+        - name: _in
+          argumentType: "[String!]!"
+        - name: _nin
+          argumentType: "[String!]!"
         - name: _gt
           argumentType: String
         - name: _gte
@@ -53,6 +57,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -64,6 +70,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt
@@ -75,6 +83,8 @@ definition:
           operatorMapping:
             _eq: _eq
             _neq: _neq
+            _in: _in
+            _nin: _nin
             _gt: _gt
             _gte: _gte
             _lt: _lt

--- a/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
+++ b/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
@@ -22,12 +22,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: BinData
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -52,12 +47,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Bool
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -100,12 +90,7 @@ definition:
                 type: named
                 name: Date
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Date
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -138,12 +123,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: DbPointer
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -194,12 +174,7 @@ definition:
                 type: named
                 name: Decimal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Decimal
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -260,12 +235,7 @@ definition:
                 type: named
                 name: Double
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Double
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -398,12 +368,7 @@ definition:
                 type: named
                 name: Int
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Int
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -478,12 +443,7 @@ definition:
                 type: named
                 name: Long
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Long
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -516,12 +476,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MaxKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -544,12 +499,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MinKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -572,12 +522,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: "Null"
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -602,12 +547,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: ObjectId
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -657,12 +597,7 @@ definition:
                 type: named
                 name: String
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: String
+              type: in
             _iregex:
               type: custom
               argument_type:
@@ -705,12 +640,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Symbol
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -751,12 +681,7 @@ definition:
                 type: named
                 name: Timestamp
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Timestamp
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -789,12 +714,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Undefined
+              type: in
             _neq:
               type: custom
               argument_type:

--- a/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
+++ b/fixtures/hasura/sample_mflix/metadata/sample_mflix.hml
@@ -21,11 +21,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: BinData
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
         Bool:
           representation:
             type: boolean
@@ -37,11 +51,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Bool
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
         Date:
           representation:
             type: timestamp
@@ -71,6 +99,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
             _lt:
               type: custom
               argument_type:
@@ -86,6 +121,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
         DbPointer:
           aggregate_functions:
             count:
@@ -95,11 +137,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: DbPointer
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
         Decimal:
           representation:
             type: bigdecimal
@@ -137,6 +193,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
             _lt:
               type: custom
               argument_type:
@@ -152,6 +215,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
         Double:
           representation:
             type: float64
@@ -189,6 +259,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
             _lt:
               type: custom
               argument_type:
@@ -204,6 +281,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
         ExtendedJSON:
           representation:
             type: json
@@ -241,6 +325,11 @@ definition:
               argument_type:
                 type: named
                 name: ExtendedJSON
+            _in:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
             _iregex:
               type: custom
               argument_type:
@@ -257,6 +346,11 @@ definition:
                 type: named
                 name: ExtendedJSON
             _neq:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
+            _nin:
               type: custom
               argument_type:
                 type: named
@@ -303,6 +397,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
             _lt:
               type: custom
               argument_type:
@@ -318,6 +419,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
         Javascript:
           aggregate_functions:
             count:
@@ -369,6 +477,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
             _lt:
               type: custom
               argument_type:
@@ -384,6 +499,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
         MaxKey:
           aggregate_functions:
             count:
@@ -393,11 +515,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MaxKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
         MinKey:
           aggregate_functions:
             count:
@@ -407,11 +543,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MinKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
         "Null":
           aggregate_functions:
             count:
@@ -421,11 +571,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: "Null"
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
         ObjectId:
           representation:
             type: string
@@ -437,11 +601,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: ObjectId
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
         Regex:
           aggregate_functions:
             count:
@@ -478,6 +656,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _iregex:
               type: custom
               argument_type:
@@ -498,6 +683,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _regex:
               type: custom
               argument_type:
@@ -512,11 +704,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Symbol
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
         Timestamp:
           aggregate_functions:
             count:
@@ -544,6 +750,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
             _lt:
               type: custom
               argument_type:
@@ -559,6 +772,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
         Undefined:
           aggregate_functions:
             count:
@@ -568,11 +788,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Undefined
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
       object_types:
         DocWithExtendedJsonValue:
           fields:
@@ -1039,7 +1273,7 @@ definition:
             name: String
       procedures: []
     capabilities:
-      version: 0.1.5
+      version: 0.1.6
       capabilities:
         query:
           aggregates: {}

--- a/fixtures/hasura/test_cases/metadata/test_cases.hml
+++ b/fixtures/hasura/test_cases/metadata/test_cases.hml
@@ -22,12 +22,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: BinData
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -52,12 +47,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Bool
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -100,12 +90,7 @@ definition:
                 type: named
                 name: Date
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Date
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -138,12 +123,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: DbPointer
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -194,12 +174,7 @@ definition:
                 type: named
                 name: Decimal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Decimal
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -260,12 +235,7 @@ definition:
                 type: named
                 name: Double
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Double
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -398,12 +368,7 @@ definition:
                 type: named
                 name: Int
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Int
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -478,12 +443,7 @@ definition:
                 type: named
                 name: Long
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Long
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -516,12 +476,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MaxKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -544,12 +499,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: MinKey
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -572,12 +522,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: "Null"
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -602,12 +547,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: ObjectId
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -657,12 +597,7 @@ definition:
                 type: named
                 name: String
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: String
+              type: in
             _iregex:
               type: custom
               argument_type:
@@ -705,12 +640,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Symbol
+              type: in
             _neq:
               type: custom
               argument_type:
@@ -751,12 +681,7 @@ definition:
                 type: named
                 name: Timestamp
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Timestamp
+              type: in
             _lt:
               type: custom
               argument_type:
@@ -789,12 +714,7 @@ definition:
             _eq:
               type: equal
             _in:
-              type: custom
-              argument_type:
-                type: array
-                element_type:
-                  type: named
-                  name: Undefined
+              type: in
             _neq:
               type: custom
               argument_type:

--- a/fixtures/hasura/test_cases/metadata/test_cases.hml
+++ b/fixtures/hasura/test_cases/metadata/test_cases.hml
@@ -21,11 +21,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: BinData
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: BinData
         Bool:
           representation:
             type: boolean
@@ -37,11 +51,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Bool
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Bool
         Date:
           representation:
             type: timestamp
@@ -71,6 +99,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
             _lt:
               type: custom
               argument_type:
@@ -86,6 +121,13 @@ definition:
               argument_type:
                 type: named
                 name: Date
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Date
         DbPointer:
           aggregate_functions:
             count:
@@ -95,11 +137,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: DbPointer
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: DbPointer
         Decimal:
           representation:
             type: bigdecimal
@@ -137,6 +193,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
             _lt:
               type: custom
               argument_type:
@@ -152,6 +215,13 @@ definition:
               argument_type:
                 type: named
                 name: Decimal
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Decimal
         Double:
           representation:
             type: float64
@@ -189,6 +259,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
             _lt:
               type: custom
               argument_type:
@@ -204,6 +281,13 @@ definition:
               argument_type:
                 type: named
                 name: Double
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Double
         ExtendedJSON:
           representation:
             type: json
@@ -266,6 +350,11 @@ definition:
               argument_type:
                 type: named
                 name: ExtendedJSON
+            _nin:
+              type: custom
+              argument_type:
+                type: named
+                name: ExtendedJSON
             _regex:
               type: custom
               argument_type:
@@ -308,6 +397,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
             _lt:
               type: custom
               argument_type:
@@ -323,6 +419,13 @@ definition:
               argument_type:
                 type: named
                 name: Int
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Int
         Javascript:
           aggregate_functions:
             count:
@@ -374,6 +477,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
             _lt:
               type: custom
               argument_type:
@@ -389,6 +499,13 @@ definition:
               argument_type:
                 type: named
                 name: Long
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Long
         MaxKey:
           aggregate_functions:
             count:
@@ -398,11 +515,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MaxKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MaxKey
         MinKey:
           aggregate_functions:
             count:
@@ -412,11 +543,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: MinKey
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: MinKey
         "Null":
           aggregate_functions:
             count:
@@ -426,11 +571,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: "Null"
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: "Null"
         ObjectId:
           representation:
             type: string
@@ -442,11 +601,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: ObjectId
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: ObjectId
         Regex:
           aggregate_functions:
             count:
@@ -483,6 +656,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _iregex:
               type: custom
               argument_type:
@@ -503,6 +683,13 @@ definition:
               argument_type:
                 type: named
                 name: String
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: String
             _regex:
               type: custom
               argument_type:
@@ -517,11 +704,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Symbol
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Symbol
         Timestamp:
           aggregate_functions:
             count:
@@ -549,6 +750,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
             _lt:
               type: custom
               argument_type:
@@ -564,6 +772,13 @@ definition:
               argument_type:
                 type: named
                 name: Timestamp
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Timestamp
         Undefined:
           aggregate_functions:
             count:
@@ -573,11 +788,25 @@ definition:
           comparison_operators:
             _eq:
               type: equal
+            _in:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
             _neq:
               type: custom
               argument_type:
                 type: named
                 name: Undefined
+            _nin:
+              type: custom
+              argument_type:
+                type: array
+                element_type:
+                  type: named
+                  name: Undefined
       object_types:
         nested_collection:
           fields:


### PR DESCRIPTION
Adds `$in` and `$nin` to all scalar types that also have `$eq` defined.