### PR TITLE
support $project stage in native query pipeline type inference

### DIFF
--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -110,6 +110,7 @@ fn infer_stage_output_type(
         }
         Stage::Facet(_) => todo!("facet stage"),
         Stage::Count(_) => todo!("count stage"),
+        Stage::Project(doc) => todo!("project stage"),
         Stage::ReplaceRoot {
             new_root: selection,
         }

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -392,7 +392,7 @@ mod tests {
         }))]);
         let config = mflix_config();
         let pipeline_types =
-            infer_pipeline_types(&config, "movies", Some(&("movies".into())), &pipeline).unwrap();
+            infer_pipeline_types(&config, "movies", Some(&("movies".into())), &pipeline)?;
         let expected = [(
             "movies_replaceWith".into(),
             ObjectType {

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -93,7 +93,7 @@ fn infer_stage_output_type(
             )?;
             None
         }
-        Stage::Sort(_) => None, // TODO: need to analyze arguments to find parameters
+        Stage::Sort(_) => None,
         Stage::Skip(expression) => {
             infer_type_from_aggregation_expression(
                 context,

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -1,4 +1,5 @@
 mod match_stage;
+mod project_stage;
 
 use std::{collections::BTreeMap, iter::once};
 
@@ -92,10 +93,26 @@ fn infer_stage_output_type(
             )?;
             None
         }
-        Stage::Sort(_) => None,
-        Stage::Limit(_) => None,
+        Stage::Sort(_) => None, // TODO: need to analyze arguments to find parameters
+        Stage::Skip(expression) => {
+            infer_type_from_aggregation_expression(
+                context,
+                desired_object_type_name,
+                Some(&TypeConstraint::Scalar(BsonScalarType::Int)),
+                expression.clone(),
+            )?;
+            None
+        }
+        Stage::Limit(expression) => {
+            infer_type_from_aggregation_expression(
+                context,
+                desired_object_type_name,
+                Some(&TypeConstraint::Scalar(BsonScalarType::Int)),
+                expression.clone(),
+            )?;
+            None
+        }
         Stage::Lookup { .. } => todo!("lookup stage"),
-        Stage::Skip(_) => None,
         Stage::Group {
             key_expression,
             accumulators,
@@ -110,7 +127,14 @@ fn infer_stage_output_type(
         }
         Stage::Facet(_) => todo!("facet stage"),
         Stage::Count(_) => todo!("count stage"),
-        Stage::Project(doc) => todo!("project stage"),
+        Stage::Project(doc) => {
+            let augmented_type = project_stage::infer_type_from_project_stage(
+                context,
+                &format!("{desired_object_type_name}_project"),
+                doc,
+            )?;
+            Some(augmented_type)
+        }
         Stage::ReplaceRoot {
             new_root: selection,
         }
@@ -295,7 +319,11 @@ fn infer_type_from_unwind_stage(
     Ok(TypeConstraint::WithFieldOverrides {
         augmented_object_type_name: format!("{desired_object_type_name}_unwind").into(),
         target_type: Box::new(context.get_input_document_type()?.clone()),
-        fields: unwind_stage_object_type.fields,
+        fields: unwind_stage_object_type
+            .fields
+            .into_iter()
+            .map(|(k, t)| (k, Some(t)))
+            .collect(),
     })
 }
 
@@ -419,13 +447,18 @@ mod tests {
                 augmented_object_type_name: "unwind_stage_unwind".into(),
                 target_type: Box::new(TypeConstraint::Variable(input_doc_variable)),
                 fields: [
-                    ("idx".into(), TypeConstraint::Scalar(BsonScalarType::Long)),
+                    (
+                        "idx".into(),
+                        Some(TypeConstraint::Scalar(BsonScalarType::Long))
+                    ),
                     (
                         "words".into(),
-                        TypeConstraint::ElementOf(Box::new(TypeConstraint::FieldOf {
-                            target_type: Box::new(TypeConstraint::Variable(input_doc_variable)),
-                            path: nonempty!["words".into()],
-                        }))
+                        Some(TypeConstraint::ElementOf(Box::new(
+                            TypeConstraint::FieldOf {
+                                target_type: Box::new(TypeConstraint::Variable(input_doc_variable)),
+                                path: nonempty!["words".into()],
+                            }
+                        )))
                     )
                 ]
                 .into(),

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -110,7 +110,10 @@ fn infer_stage_output_type(
         }
         Stage::Facet(_) => todo!("facet stage"),
         Stage::Count(_) => todo!("count stage"),
-        Stage::ReplaceWith(selection) => {
+        Stage::ReplaceRoot {
+            new_root: selection,
+        }
+        | Stage::ReplaceWith(selection) => {
             let selection: &Document = selection.into();
             Some(
                 aggregation_expression::infer_type_from_aggregation_expression(

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -55,7 +55,7 @@ pub fn infer_pipeline_types(
     if let TypeConstraint::Object(stage_type_name) = last_stage_type {
         if let Some(object_type) = context.get_object_type(&stage_type_name) {
             context.insert_object_type(object_type_name.clone(), object_type.into_owned());
-            context.set_stage_doc_type(TypeConstraint::Object(object_type_name))
+            context.set_stage_doc_type(TypeConstraint::Object(object_type_name));
         }
     }
 

--- a/crates/cli/src/native_query/pipeline/project_stage.rs
+++ b/crates/cli/src/native_query/pipeline/project_stage.rs
@@ -1,0 +1,348 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    str::FromStr as _,
+};
+
+use itertools::Itertools as _;
+use mongodb::bson::{Bson, Decimal128, Document};
+use mongodb_support::BsonScalarType;
+use ndc_models::{FieldName, ObjectTypeName};
+use nonempty::NonEmpty;
+
+use crate::native_query::{
+    aggregation_expression::infer_type_from_aggregation_expression,
+    error::{Error, Result},
+    pipeline_type_context::PipelineTypeContext,
+    type_constraint::{ObjectTypeConstraint, TypeConstraint},
+};
+
+enum Mode {
+    Exclusion,
+    Inclusion,
+}
+
+// $project has two distinct behaviors:
+//
+// Exclusion mode: if every value in the projection document is `false` or `0` then the output
+// preserves fields from the input except for fields that are specifically excluded. The special
+// value `$$REMOVE` **cannot** be used in this mode.
+//
+// Inclusion (replace) mode: if any value in the projection document specifies a field for
+// inclusion, replaces the value of an input field with a new value, adds a new field with a new
+// value, or removes a field with the special value `$$REMOVE` then output excludes input fields
+// that are not specified. The output is composed solely of fields specified in the projection
+// document, plus `_id` unless `_id` is specifically excluded. Values of `false` or `0` are not
+// allowed in this mode except to suppress `_id`.
+//
+// TODO: This implementation does not fully account for uses of $$REMOVE. It does correctly select
+// inclusion mode if $$REMOVE is used. A complete implementation would infer a nullable type for
+// a projection that conditionally resolves to $$REMOVE.
+pub fn infer_type_from_project_stage(
+    context: &mut PipelineTypeContext<'_>,
+    desired_object_type_name: &str,
+    projection: &Document,
+) -> Result<TypeConstraint> {
+    let mode = if projection.values().all(is_false_or_zero) {
+        Mode::Exclusion
+    } else {
+        Mode::Inclusion
+    };
+    match mode {
+        Mode::Exclusion => exclusion_projection_type(context, desired_object_type_name, projection),
+        Mode::Inclusion => inclusion_projection_type(context, desired_object_type_name, projection),
+    }
+}
+
+// TODO: Handle keys with dots
+fn exclusion_projection_type(
+    context: &mut PipelineTypeContext<'_>,
+    desired_object_type_name: &str,
+    projection: &Document,
+) -> Result<TypeConstraint> {
+    let subtracted_fields = projection
+        .keys()
+        .map(|k| (k.clone().into(), None))
+        .collect();
+    let input_type = context.get_input_document_type()?;
+    let augmented_type = TypeConstraint::WithFieldOverrides {
+        augmented_object_type_name: desired_object_type_name.into(),
+        target_type: Box::new(input_type),
+        fields: subtracted_fields,
+    };
+    Ok(augmented_type)
+}
+
+fn inclusion_projection_type(
+    context: &mut PipelineTypeContext<'_>,
+    desired_object_type_name: &str,
+    projection: &Document,
+) -> Result<TypeConstraint> {
+    let input_type = context.get_input_document_type()?;
+
+    // Projection keys can be dot-separated paths to nested fields. In this case a single
+    // object-type output field might be specified by multiple project keys. We collect sets of
+    // each top-level key (the first component of a dot-separated path), and then merge
+    // constraints.
+    let mut specifications: HashMap<FieldName, ProjectionTree> = Default::default();
+
+    let added_fields = projection
+        .iter()
+        .filter(|(_, spec)| !is_false_or_zero(spec));
+
+    for (field_name, spec) in added_fields {
+        let path = field_name.split(".").map(|s| s.into()).collect_vec();
+        let projected_type = if is_true_or_one(spec) {
+            TypeConstraint::FieldOf {
+                target_type: Box::new(input_type.clone()),
+                path: NonEmpty::from_slice(&path).ok_or_else(|| {
+                    Error::Other("key in $project stage is an empty string".to_string())
+                })?,
+            }
+        } else {
+            let desired_object_type_name = format!("{desired_object_type_name}_{field_name}");
+            infer_type_from_aggregation_expression(
+                context,
+                &desired_object_type_name,
+                None,
+                spec.clone(),
+            )?
+        };
+        ProjectionTree::insert_specification(&mut specifications, &path, projected_type)?;
+    }
+
+    let specifies_id = projection.keys().any(|k| k == "_id");
+    if !specifies_id {
+        ProjectionTree::insert_specification(
+            &mut specifications,
+            &["_id".into()],
+            TypeConstraint::Scalar(BsonScalarType::ObjectId),
+        )?;
+    }
+
+    let object_type_name =
+        ProjectionTree::into_object_type(context, desired_object_type_name, specifications);
+
+    Ok(TypeConstraint::Object(object_type_name))
+}
+
+enum ProjectionTree {
+    Object(HashMap<FieldName, ProjectionTree>),
+    Field(TypeConstraint),
+}
+
+impl ProjectionTree {
+    fn insert_specification(
+        specifications: &mut HashMap<FieldName, ProjectionTree>,
+        path: &[FieldName],
+        field_type: TypeConstraint,
+    ) -> Result<()> {
+        match path {
+            [] => Err(Error::Other(
+                "invalid $project: a projection key is an empty string".into(),
+            ))?,
+            [field_name] => {
+                let maybe_old_value =
+                    specifications.insert(field_name.clone(), ProjectionTree::Field(field_type));
+                if maybe_old_value.is_some() {
+                    Err(path_collision_error(path))?;
+                };
+            }
+            [first_field_name, rest @ ..] => {
+                let entry = specifications.entry(first_field_name.clone());
+                match entry {
+                    Entry::Occupied(mut e) => match e.get_mut() {
+                        ProjectionTree::Object(sub_specs) => {
+                            Self::insert_specification(sub_specs, rest, field_type)?;
+                        }
+                        ProjectionTree::Field(_) => Err(path_collision_error(path))?,
+                    },
+                    Entry::Vacant(entry) => {
+                        let mut sub_specs = Default::default();
+                        Self::insert_specification(&mut sub_specs, rest, field_type)?;
+                        entry.insert(ProjectionTree::Object(sub_specs));
+                    }
+                };
+            }
+        }
+        Ok(())
+    }
+
+    fn into_object_type(
+        context: &mut PipelineTypeContext<'_>,
+        desired_object_type_name: &str,
+        specifications: HashMap<FieldName, ProjectionTree>,
+    ) -> ObjectTypeName {
+        let fields = specifications
+            .into_iter()
+            .map(|(field_name, spec)| {
+                let field_type = match spec {
+                    ProjectionTree::Field(field_type) => field_type,
+                    ProjectionTree::Object(sub_specs) => {
+                        let desired_object_type_name =
+                            format!("{desired_object_type_name}_{field_name}");
+                        let nested_object_name =
+                            Self::into_object_type(context, &desired_object_type_name, sub_specs);
+                        TypeConstraint::Object(nested_object_name)
+                    }
+                };
+                (field_name, field_type)
+            })
+            .collect();
+        let object_type = ObjectTypeConstraint { fields };
+        let object_type_name = context.unique_type_name(desired_object_type_name);
+        context.insert_object_type(object_type_name.clone(), object_type);
+        object_type_name
+    }
+}
+
+// Experimentation confirms that a zero value of any numeric type is interpreted as suppression of
+// a field.
+fn is_false_or_zero(x: &Bson) -> bool {
+    let decimal_zero = Decimal128::from_str("0").expect("parse 0 as decimal");
+    matches!(
+        x,
+        Bson::Boolean(false) | Bson::Int32(0) | Bson::Int64(0) | Bson::Double(0.0)
+    ) || x == &Bson::Decimal128(decimal_zero)
+}
+
+fn is_true_or_one(x: &Bson) -> bool {
+    let decimal_one = Decimal128::from_str("1").expect("parse 1 as decimal");
+    matches!(
+        x,
+        Bson::Boolean(true) | Bson::Int32(1) | Bson::Int64(1) | Bson::Double(1.0)
+    ) || x == &Bson::Decimal128(decimal_one)
+}
+
+fn path_collision_error(path: impl IntoIterator<Item = impl std::fmt::Display>) -> Error {
+    Error::Other(format!(
+        "invalid $project: path collision at {}",
+        path.into_iter().join(".")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use mongodb::bson::doc;
+    use mongodb_support::BsonScalarType;
+    use nonempty::nonempty;
+    use pretty_assertions::assert_eq;
+    use test_helpers::configuration::mflix_config;
+
+    use crate::native_query::{
+        pipeline_type_context::PipelineTypeContext,
+        type_constraint::{ObjectTypeConstraint, TypeConstraint, TypeVariable, Variance},
+    };
+
+    #[test]
+    fn infers_type_of_projection_in_inclusion_mode() -> anyhow::Result<()> {
+        let config = mflix_config();
+        let mut context = PipelineTypeContext::new(&config, None);
+        context.set_stage_doc_type(TypeConstraint::Object("movies".into()));
+        let input_type = || {
+            Box::new(TypeConstraint::Variable(TypeVariable::new(
+                0,
+                Variance::Covariant,
+            )))
+        };
+
+        let input = doc! {
+            "title": 1,
+            "tomatoes.critic.rating": true,
+            "tomatoes.critic.meter": true,
+            "tomatoes.lastUpdated": true,
+            "releaseDate": "$released",
+        };
+
+        let inferred_type =
+            super::infer_type_from_project_stage(&mut context, "Movie_project", &input)?;
+
+        assert_eq!(
+            inferred_type,
+            TypeConstraint::Object("Movie_project".into())
+        );
+
+        let object_types = context.object_types();
+        let expected_object_types = [
+            (
+                "Movie_project".into(),
+                ObjectTypeConstraint {
+                    fields: [
+                        (
+                            "_id".into(),
+                            TypeConstraint::Scalar(BsonScalarType::ObjectId),
+                        ),
+                        (
+                            "title".into(),
+                            TypeConstraint::FieldOf {
+                                target_type: input_type(),
+                                path: nonempty!["title".into()],
+                            },
+                        ),
+                        (
+                            "tomatoes".into(),
+                            TypeConstraint::Object("Movie_project_tomatoes".into()),
+                        ),
+                        (
+                            "releaseDate".into(),
+                            TypeConstraint::FieldOf {
+                                target_type: input_type(),
+                                path: nonempty!["released".into()],
+                            },
+                        ),
+                    ]
+                    .into(),
+                },
+            ),
+            (
+                "Movie_project_tomatoes".into(),
+                ObjectTypeConstraint {
+                    fields: [
+                        (
+                            "critic".into(),
+                            TypeConstraint::Object("Movie_project_tomatoes_critic".into()),
+                        ),
+                        (
+                            "lastUpdated".into(),
+                            TypeConstraint::FieldOf {
+                                target_type: input_type(),
+                                path: nonempty!["tomatoes".into(), "lastUpdated".into()],
+                            },
+                        ),
+                    ]
+                    .into(),
+                },
+            ),
+            (
+                "Movie_project_tomatoes_critic".into(),
+                ObjectTypeConstraint {
+                    fields: [
+                        (
+                            "rating".into(),
+                            TypeConstraint::FieldOf {
+                                target_type: input_type(),
+                                path: nonempty![
+                                    "tomatoes".into(),
+                                    "critic".into(),
+                                    "rating".into()
+                                ],
+                            },
+                        ),
+                        (
+                            "meter".into(),
+                            TypeConstraint::FieldOf {
+                                target_type: input_type(),
+                                path: nonempty!["tomatoes".into(), "critic".into(), "meter".into()],
+                            },
+                        ),
+                    ]
+                    .into(),
+                },
+            ),
+        ]
+        .into();
+
+        assert_eq!(object_types, &expected_object_types);
+
+        Ok(())
+    }
+}

--- a/crates/cli/src/native_query/pipeline/project_stage.rs
+++ b/crates/cli/src/native_query/pipeline/project_stage.rs
@@ -365,94 +365,31 @@ mod tests {
                     ("title".into(), None),
                     (
                         "tomatoes".into(),
-                        Some(TypeConstraint::Object("Movie_project_tomatoes".into()))
+                        Some(TypeConstraint::WithFieldOverrides {
+                            augmented_object_type_name: "Movie_project_tomatoes".into(),
+                            target_type: Box::new(TypeConstraint::Object("Tomatoes".into())),
+                            fields: [
+                                ("lastUpdated".into(), None),
+                                (
+                                    "critic".into(),
+                                    Some(TypeConstraint::WithFieldOverrides {
+                                        augmented_object_type_name: "Movie_project_tomatoes_critic"
+                                            .into(),
+                                        target_type: Box::new(TypeConstraint::Object(
+                                            "TomatoesCritic".into()
+                                        )),
+                                        fields: [("rating".into(), None), ("meter".into(), None),]
+                                            .into(),
+                                    })
+                                )
+                            ]
+                            .into(),
+                        })
                     ),
                 ]
                 .into(),
             }
         );
-
-        let object_types = context.object_types();
-        let expected_object_types = [
-            (
-                "Movie_project".into(),
-                ObjectTypeConstraint {
-                    fields: [
-                        (
-                            "_id".into(),
-                            TypeConstraint::Scalar(BsonScalarType::ObjectId),
-                        ),
-                        (
-                            "title".into(),
-                            TypeConstraint::FieldOf {
-                                target_type: Box::new(input_type.clone()),
-                                path: nonempty!["title".into()],
-                            },
-                        ),
-                        (
-                            "tomatoes".into(),
-                            TypeConstraint::Object("Movie_project_tomatoes".into()),
-                        ),
-                        (
-                            "releaseDate".into(),
-                            TypeConstraint::FieldOf {
-                                target_type: Box::new(input_type.clone()),
-                                path: nonempty!["released".into()],
-                            },
-                        ),
-                    ]
-                    .into(),
-                },
-            ),
-            (
-                "Movie_project_tomatoes".into(),
-                ObjectTypeConstraint {
-                    fields: [
-                        (
-                            "critic".into(),
-                            TypeConstraint::Object("Movie_project_tomatoes_critic".into()),
-                        ),
-                        (
-                            "lastUpdated".into(),
-                            TypeConstraint::FieldOf {
-                                target_type: Box::new(input_type.clone()),
-                                path: nonempty!["tomatoes".into(), "lastUpdated".into()],
-                            },
-                        ),
-                    ]
-                    .into(),
-                },
-            ),
-            (
-                "Movie_project_tomatoes_critic".into(),
-                ObjectTypeConstraint {
-                    fields: [
-                        (
-                            "rating".into(),
-                            TypeConstraint::FieldOf {
-                                target_type: Box::new(input_type.clone()),
-                                path: nonempty![
-                                    "tomatoes".into(),
-                                    "critic".into(),
-                                    "rating".into()
-                                ],
-                            },
-                        ),
-                        (
-                            "meter".into(),
-                            TypeConstraint::FieldOf {
-                                target_type: Box::new(input_type.clone()),
-                                path: nonempty!["tomatoes".into(), "critic".into(), "meter".into()],
-                            },
-                        ),
-                    ]
-                    .into(),
-                },
-            ),
-        ]
-        .into();
-
-        assert_eq!(object_types, &expected_object_types);
 
         Ok(())
     }

--- a/crates/cli/src/native_query/pipeline_type_context.rs
+++ b/crates/cli/src/native_query/pipeline_type_context.rs
@@ -284,9 +284,10 @@ impl PipelineTypeContext<'_> {
         )
     }
 
-    pub fn set_stage_doc_type(&mut self, doc_type: TypeConstraint) {
+    pub fn set_stage_doc_type(&mut self, doc_type: TypeConstraint) -> TypeConstraint {
         let variable = self.new_type_variable(Variance::Covariant, [doc_type]);
         self.input_doc_type = Some(variable);
+        TypeConstraint::Variable(variable)
     }
 
     pub fn add_warning(&mut self, warning: Error) {

--- a/crates/cli/src/native_query/pipeline_type_context.rs
+++ b/crates/cli/src/native_query/pipeline_type_context.rs
@@ -65,7 +65,7 @@ impl PipelineTypeContext<'_> {
         };
 
         if let Some(type_name) = input_collection_document_type {
-            context.set_stage_doc_type(TypeConstraint::Object(type_name))
+            context.set_stage_doc_type(TypeConstraint::Object(type_name));
         }
 
         context

--- a/crates/cli/src/native_query/pipeline_type_context.rs
+++ b/crates/cli/src/native_query/pipeline_type_context.rs
@@ -72,6 +72,11 @@ impl PipelineTypeContext<'_> {
     }
 
     #[cfg(test)]
+    pub fn object_types(&self) -> &BTreeMap<ObjectTypeName, ObjectTypeConstraint> {
+        &self.object_types
+    }
+
+    #[cfg(test)]
     pub fn type_variables(&self) -> &HashMap<TypeVariable, BTreeSet<TypeConstraint>> {
         &self.type_variables
     }
@@ -240,7 +245,8 @@ impl PipelineTypeContext<'_> {
                 self.constraint_references_variable(target_type, variable)
                     || fields
                         .iter()
-                        .any(|(_, t)| self.constraint_references_variable(t, variable))
+                        .flat_map(|(_, t)| t)
+                        .any(|t| self.constraint_references_variable(t, variable))
             }
         }
     }

--- a/crates/cli/src/native_query/tests.rs
+++ b/crates/cli/src/native_query/tests.rs
@@ -351,7 +351,6 @@ fn supports_project_stage_in_exclusion_mode() -> Result<()> {
         _ => panic!("tomatoes field does not have an object type"),
     };
     let tomatoes_type = &native_query.object_types[&tomatoes_type_name];
-    expect_false!(tomatoes_type.fields.contains_key("title"));
     expect_that!(
         tomatoes_type.fields.keys().collect_vec(),
         unordered_elements_are![&&FieldName::from("viewer"), &&FieldName::from("critic")]

--- a/crates/cli/src/native_query/tests.rs
+++ b/crates/cli/src/native_query/tests.rs
@@ -9,12 +9,13 @@ use configuration::{
     Configuration,
 };
 use googletest::prelude::*;
+use itertools::Itertools as _;
 use mongodb::bson::doc;
 use mongodb_support::{
     aggregate::{Accumulator, Pipeline, Selection, Stage},
     BsonScalarType,
 };
-use ndc_models::ObjectTypeName;
+use ndc_models::{FieldName, ObjectTypeName};
 use pretty_assertions::assert_eq;
 use test_helpers::configuration::mflix_config;
 
@@ -318,6 +319,121 @@ fn supports_various_aggregation_operators() -> googletest::Result<()> {
             ]),
             description: None,
         }
+    );
+
+    Ok(())
+}
+
+#[googletest::test]
+fn supports_project_stage_in_exclusion_mode() -> Result<()> {
+    let config = mflix_config();
+
+    let pipeline = Pipeline::new(vec![Stage::Project(doc! {
+        "title": 0,
+        "tomatoes.critic.rating": false,
+        "tomatoes.critic.meter": false,
+        "tomatoes.lastUpdated": false,
+    })]);
+
+    let native_query =
+        native_query_from_pipeline(&config, "project_test", Some("movies".into()), pipeline)?;
+
+    let result_type_name = native_query.result_document_type;
+    let result_type = &native_query.object_types[&result_type_name];
+
+    expect_false!(result_type.fields.contains_key("title"));
+
+    let tomatoes_type_name = match result_type.fields.get("tomatoes") {
+        Some(ObjectField {
+            r#type: Type::Object(name),
+            ..
+        }) => ObjectTypeName::from(name.clone()),
+        _ => panic!("tomatoes field does not have an object type"),
+    };
+    let tomatoes_type = &native_query.object_types[&tomatoes_type_name];
+    expect_false!(tomatoes_type.fields.contains_key("title"));
+    expect_that!(
+        tomatoes_type.fields.keys().collect_vec(),
+        unordered_elements_are![&&FieldName::from("viewer"), &&FieldName::from("critic")]
+    );
+    expect_eq!(
+        tomatoes_type.fields["viewer"].r#type,
+        Type::Object("TomatoesCriticViewer".into()),
+    );
+
+    let critic_type_name = match tomatoes_type.fields.get("critic") {
+        Some(ObjectField {
+            r#type: Type::Object(name),
+            ..
+        }) => ObjectTypeName::from(name.clone()),
+        _ => panic!("tomatoes.critic field does not have an object type"),
+    };
+    let critic_type = &native_query.object_types[&critic_type_name];
+    expect_eq!(
+        critic_type.fields,
+        object_fields([("numReviews", Type::Scalar(BsonScalarType::Int))]),
+    );
+
+    Ok(())
+}
+
+#[googletest::test]
+fn supports_project_stage_in_inclusion_mode() -> Result<()> {
+    let config = mflix_config();
+
+    let pipeline = Pipeline::new(vec![Stage::Project(doc! {
+        "title": 1,
+        "tomatoes.critic.rating": true,
+        "tomatoes.critic.meter": true,
+        "tomatoes.lastUpdated": true,
+        "releaseDate": "$released",
+    })]);
+
+    let native_query =
+        native_query_from_pipeline(&config, "inclusion", Some("movies".into()), pipeline)?;
+
+    expect_eq!(native_query.result_document_type, "inclusion_project".into());
+
+    expect_eq!(
+        native_query.object_types,
+        [
+            (
+                "inclusion_project".into(),
+                ObjectType {
+                    fields: object_fields([
+                        ("_id", Type::Scalar(BsonScalarType::ObjectId)),
+                        ("title", Type::Scalar(BsonScalarType::String)),
+                        ("tomatoes", Type::Object("inclusion_project_tomatoes".into())),
+                        ("releaseDate", Type::Scalar(BsonScalarType::Date)),
+                    ]),
+                    description: None
+                }
+            ),
+            (
+                "inclusion_project_tomatoes".into(),
+                ObjectType {
+                    fields: object_fields([
+                        (
+                            "critic",
+                            Type::Object("inclusion_project_tomatoes_critic".into())
+                        ),
+                        ("lastUpdated", Type::Scalar(BsonScalarType::Date)),
+                    ]),
+                    description: None
+                }
+            ),
+            (
+                "inclusion_project_tomatoes_critic".into(),
+                ObjectType {
+                    fields: object_fields([
+                        ("rating", Type::Scalar(BsonScalarType::Double)),
+                        ("meter", Type::Scalar(BsonScalarType::Int)),
+                    ]),
+                    description: None
+                }
+            )
+        ]
+        .into(),
     );
 
     Ok(())

--- a/crates/cli/src/native_query/type_constraint.rs
+++ b/crates/cli/src/native_query/type_constraint.rs
@@ -81,11 +81,11 @@ pub enum TypeConstraint {
         path: NonEmpty<FieldName>,
     },
 
-    /// A type that modifies another type by adding or replacing object fields.
+    /// A type that modifies another type by adding, replacing, or subtracting object fields.
     WithFieldOverrides {
         augmented_object_type_name: ObjectTypeName,
         target_type: Box<TypeConstraint>,
-        fields: BTreeMap<FieldName, TypeConstraint>,
+        fields: BTreeMap<FieldName, Option<TypeConstraint>>,
     },
 }
 
@@ -122,6 +122,7 @@ impl TypeConstraint {
             } => {
                 let overridden_field_complexity: usize = fields
                     .values()
+                    .flatten()
                     .map(|constraint| constraint.complexity())
                     .sum();
                 2 + target_type.complexity() + overridden_field_complexity

--- a/crates/cli/src/native_query/type_solver/constraint_to_type.rs
+++ b/crates/cli/src/native_query/type_solver/constraint_to_type.rs
@@ -16,6 +16,8 @@ use TypeConstraint as C;
 
 /// In cases where there is enough information present in one constraint itself to infer a concrete
 /// type, do that. Returns None if there is not enough information present.
+///
+/// TODO: Most of this logic should be moved to `simplify_one`
 pub fn constraint_to_type(
     configuration: &Configuration,
     solutions: &HashMap<TypeVariable, Type>,
@@ -124,8 +126,9 @@ pub fn constraint_to_type(
                 object_type_constraints,
                 target_type,
             )?;
-            let resolved_field_types: Option<Vec<(FieldName, Type)>> = fields
+            let added_or_replaced_fields: Option<Vec<(FieldName, Type)>> = fields
                 .iter()
+                .flat_map(|(field_name, option_t)| option_t.as_ref().map(|t| (field_name, t)))
                 .map(|(field_name, t)| {
                     Ok(constraint_to_type(
                         configuration,
@@ -137,15 +140,23 @@ pub fn constraint_to_type(
                     .map(|t| (field_name.clone(), t)))
                 })
                 .collect::<Result<_>>()?;
-            match (resolved_object_type, resolved_field_types) {
-                (Some(object_type), Some(fields)) => with_field_overrides(
+            let subtracted_fields = fields
+                .iter()
+                .filter_map(|(n, option_t)| match option_t {
+                    Some(_) => None,
+                    None => Some(n),
+                })
+                .collect_vec();
+            match (resolved_object_type, added_or_replaced_fields) {
+                (Some(object_type), Some(added_fields)) => with_field_overrides(
                     configuration,
                     solutions,
                     added_object_types,
                     object_type_constraints,
                     object_type,
                     augmented_object_type_name.clone(),
-                    fields,
+                    added_fields,
+                    subtracted_fields,
                 )?,
                 _ => None,
             }
@@ -274,14 +285,16 @@ fn field_of<'a>(
     Ok(field_type.map(Type::normalize_type))
 }
 
-fn with_field_overrides(
+#[allow(clippy::too_many_arguments)]
+fn with_field_overrides<'a>(
     configuration: &Configuration,
     solutions: &HashMap<TypeVariable, Type>,
     added_object_types: &mut BTreeMap<ObjectTypeName, ObjectType>,
     object_type_constraints: &mut BTreeMap<ObjectTypeName, ObjectTypeConstraint>,
     object_type: Type,
     augmented_object_type_name: ObjectTypeName,
-    fields: impl IntoIterator<Item = (FieldName, Type)>,
+    added_or_replaced_fields: impl IntoIterator<Item = (FieldName, Type)>,
+    subtracted_fields: impl IntoIterator<Item = &'a FieldName>,
 ) -> Result<Option<Type>> {
     let augmented_object_type = match object_type {
         Type::ExtendedJSON => Some(Type::ExtendedJSON),
@@ -297,7 +310,7 @@ fn with_field_overrides(
                 return Ok(None);
             };
             let mut new_object_type = object_type.clone();
-            for (field_name, field_type) in fields.into_iter() {
+            for (field_name, field_type) in added_or_replaced_fields.into_iter() {
                 new_object_type.fields.insert(
                     field_name,
                     ObjectField {
@@ -305,6 +318,9 @@ fn with_field_overrides(
                         description: None,
                     },
                 );
+            }
+            for field_name in subtracted_fields {
+                new_object_type.fields.remove(field_name);
             }
             // We might end up back-tracking in which case this will register an object type that
             // isn't referenced. BUT once solving is complete we should get here again with the
@@ -321,7 +337,8 @@ fn with_field_overrides(
                 object_type_constraints,
                 *t,
                 augmented_object_type_name,
-                fields,
+                added_or_replaced_fields,
+                subtracted_fields,
             )?;
             underlying_type.map(|t| Type::Nullable(Box::new(t)))
         }

--- a/crates/cli/src/native_query/type_solver/mod.rs
+++ b/crates/cli/src/native_query/type_solver/mod.rs
@@ -35,7 +35,24 @@ pub fn unify(
     }
 
     #[cfg(test)]
-    println!("begin unify:\n  type_variables: {type_variables:?}\n  object_type_constraints: {object_type_constraints:?}\n");
+    {
+        println!("begin unify:");
+        println!("  type_variables:");
+        for (var, constraints) in type_variables.iter() {
+            println!(
+                "  - {var}: {}",
+                constraints.iter().map(|c| format!("{c}")).join("; ")
+            );
+        }
+        println!(" object_type_constraints:");
+        for (name, ot) in object_type_constraints.iter() {
+            println!("  {name} ::",);
+            for (field_name, field_type) in ot.fields.iter() {
+                println!("    - {field_name}: {field_type}")
+            }
+        }
+        println!();
+    }
 
     loop {
         let prev_type_variables = type_variables.clone();

--- a/crates/mongodb-agent-common/src/query/pipeline.rs
+++ b/crates/mongodb-agent-common/src/query/pipeline.rs
@@ -78,7 +78,7 @@ pub fn pipeline_for_non_foreach(
         .map(make_sort_stages)
         .flatten_ok()
         .collect::<Result<Vec<_>, _>>()?;
-    let skip_stage = offset.map(Stage::Skip);
+    let skip_stage = offset.map(Into::into).map(Stage::Skip);
 
     match_stage
         .into_iter()
@@ -132,7 +132,7 @@ pub fn pipeline_for_fields_facet(
         }
     }
 
-    let limit_stage = limit.map(Stage::Limit);
+    let limit_stage = limit.map(Into::into).map(Stage::Limit);
     let replace_with_stage: Stage = Stage::ReplaceWith(selection);
 
     Ok(Pipeline::from_iter(
@@ -245,7 +245,7 @@ fn pipeline_for_aggregate(
                 Some(Stage::Match(
                     bson::doc! { column.as_str(): { "$exists": true, "$ne": null } },
                 )),
-                limit.map(Stage::Limit),
+                limit.map(Into::into).map(Stage::Limit),
                 Some(Stage::Group {
                     key_expression: field_ref(column.as_str()),
                     accumulators: [].into(),
@@ -261,7 +261,7 @@ fn pipeline_for_aggregate(
                 Some(Stage::Match(
                     bson::doc! { column.as_str(): { "$exists": true, "$ne": null } },
                 )),
-                limit.map(Stage::Limit),
+                limit.map(Into::into).map(Stage::Limit),
                 Some(Stage::Count(RESULT_FIELD.to_string())),
             ]
             .into_iter()
@@ -285,7 +285,7 @@ fn pipeline_for_aggregate(
                     Some(Stage::Match(
                         bson::doc! { column: { "$exists": true, "$ne": null } },
                     )),
-                    limit.map(Stage::Limit),
+                    limit.map(Into::into).map(Stage::Limit),
                     Some(Stage::Group {
                         key_expression: Bson::Null,
                         accumulators: [(RESULT_FIELD.to_string(), accumulator)].into(),
@@ -298,7 +298,7 @@ fn pipeline_for_aggregate(
 
         Aggregate::StarCount {} => Pipeline::from_iter(
             [
-                limit.map(Stage::Limit),
+                limit.map(Into::into).map(Stage::Limit),
                 Some(Stage::Count(RESULT_FIELD.to_string())),
             ]
             .into_iter()

--- a/crates/mongodb-agent-common/src/query/relations.rs
+++ b/crates/mongodb-agent-common/src/query/relations.rs
@@ -855,7 +855,7 @@ mod tests {
             }
           },
           {
-            "$limit": Bson::Int64(50),
+            "$limit": Bson::Int32(50),
           },
           {
             "$replaceWith": {
@@ -975,7 +975,7 @@ mod tests {
                 }
             },
             {
-                "$limit": Bson::Int64(50),
+                "$limit": Bson::Int32(50),
             },
             {
                 "$replaceWith": {

--- a/crates/mongodb-support/src/aggregate/stage.rs
+++ b/crates/mongodb-support/src/aggregate/stage.rs
@@ -158,6 +158,16 @@ pub enum Stage {
     ///
     /// $replaceWith is an alias for $replaceRoot stage.
     ///
+    /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceRoot/#mongodb-pipeline-pipe.-replaceRoot
+    #[serde(rename = "$replaceWith", rename_all = "camelCase")]
+    ReplaceRoot { new_root: Selection },
+
+    /// Replaces a document with the specified embedded document. The operation replaces all
+    /// existing fields in the input document, including the _id field. Specify a document embedded
+    /// in the input document to promote the embedded document to the top level.
+    ///
+    /// $replaceWith is an alias for $replaceRoot stage.
+    ///
     /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/replaceWith/#mongodb-pipeline-pipe.-replaceWith
     #[serde(rename = "$replaceWith")]
     ReplaceWith(Selection),

--- a/crates/mongodb-support/src/aggregate/stage.rs
+++ b/crates/mongodb-support/src/aggregate/stage.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use mongodb::bson;
+use mongodb::bson::{self, Bson};
 use serde::{Deserialize, Serialize};
 
 use super::{Accumulator, Pipeline, Selection, SortDocument};
@@ -50,7 +50,7 @@ pub enum Stage {
     ///
     /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/#mongodb-pipeline-pipe.-limit
     #[serde(rename = "$limit")]
-    Limit(u32),
+    Limit(Bson),
 
     /// Performs a left outer join to another collection in the same database to filter in
     /// documents from the "joined" collection for processing.
@@ -114,7 +114,7 @@ pub enum Stage {
     ///
     /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/#mongodb-pipeline-pipe.-skip
     #[serde(rename = "$skip")]
-    Skip(u32),
+    Skip(Bson),
 
     /// Groups input documents by a specified identifier expression and applies the accumulator
     /// expression(s), if specified, to each group. Consumes all input documents and outputs one
@@ -151,6 +151,15 @@ pub enum Stage {
     /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/count/#mongodb-pipeline-pipe.-count
     #[serde(rename = "$count")]
     Count(String),
+
+    /// Reshapes each document in the stream, such as by adding new fields or removing existing
+    /// fields. For each input document, outputs one document.
+    ///
+    /// See also $unset for removing existing fields.
+    ///
+    /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/#mongodb-pipeline-pipe.-project
+    #[serde(rename = "$project")]
+    Project(bson::Document),
 
     /// Replaces a document with the specified embedded document. The operation replaces all
     /// existing fields in the input document, including the _id field. Specify a document embedded


### PR DESCRIPTION
This is work an an in-progress feature that is gated behind a feature flag, `native-query-subcommand`.

This change allows the native query configuration generator to infer the output type of [`$project`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/) stages in pipelines. It also enables inference for parameters used in `$limit` and `$skip` stages.

`$project` is a complicated feature, but it's important to support it because it's widely used. It allows adding, removing, or modifying document fields in the document-processing pipeline. It has two modes: it can either remove fields, or it can select a subset of fields to keep while optionally adding more or changing values of kept fields. It also has dotted-path notation for easily manipulating nested structures.