### PR TITLE
parse parameter type annotations when generating native query configuration

### DIFF
--- a/crates/cli/proptest-regressions/introspection/type_unification.txt
+++ b/crates/cli/proptest-regressions/introspection/type_unification.txt
@@ -9,3 +9,4 @@ cc e7368f0503761c52e2ce47fa2e64454ecd063f2e019c511759162d0be049e665 # shrinks to
 cc bd6f440b7ea7e51d8c369e802b8cbfbc0c3f140c01cd6b54d9c61e6d84d7e77d # shrinks to c = TypeUnificationContext { object_type_name: "", field_name: "" }, t = Nullable(Scalar(Null))
 cc d16279848ea51c4be376436423d342afd077a737efcab03ba2d29d5a0dee9df2 # shrinks to left = {"": Scalar(Double)}, right = {"": Scalar(Decimal)}, shared = {}
 cc fc85c97eeccb12e144f548fe65fd262d4e7b1ec9c799be69fd30535aa032e26d # shrinks to ta = Nullable(Scalar(Null)), tb = Nullable(Scalar(Undefined))
+cc 57b3015ca6d70f8e1975e21132e7624132bfe3bf958475473e5d1027c59dc7d9 # shrinks to t = Predicate { object_type_name: ObjectTypeName(TypeName("A")) }

--- a/crates/cli/proptest-regressions/native_query/type_annotation.txt
+++ b/crates/cli/proptest-regressions/native_query/type_annotation.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 525ecaf39caf362837e1addccbf4e0f4301e7e0ad1f84047a952b6ac710f795f # shrinks to t = Scalar(Double)
+cc 893face3f71cf906a1a089e94527e12d36882624d651797754b0d622f7af7680 # shrinks to t = Scalar(JavascriptWithScope)
+cc 6500920ee0ab41ac265301e4afdc05438df74f2b92112a7c0c1ccb59f056071c # shrinks to t = ArrayOf(Scalar(Double))
+cc adf516fe79b0dc9248c54a23f8b301ad1e2a3280081cde3f89586e4b5ade1065 # shrinks to t = Nullable(Nullable(Scalar(Double)))

--- a/crates/cli/src/exit_codes.rs
+++ b/crates/cli/src/exit_codes.rs
@@ -2,6 +2,7 @@
 pub enum ExitCode {
     CouldNotReadAggregationPipeline,
     CouldNotReadConfiguration,
+    CouldNotProcessAggregationPipeline,
     ErrorWriting,
     RefusedToOverwrite,
 }
@@ -11,6 +12,7 @@ impl From<ExitCode> for i32 {
         match value {
             ExitCode::CouldNotReadAggregationPipeline => 201,
             ExitCode::CouldNotReadConfiguration => 202,
+            ExitCode::CouldNotProcessAggregationPipeline => 205,
             ExitCode::ErrorWriting => 204,
             ExitCode::RefusedToOverwrite => 203,
         }

--- a/crates/cli/src/introspection/type_unification.rs
+++ b/crates/cli/src/introspection/type_unification.rs
@@ -67,6 +67,25 @@ pub fn unify_type(type_a: Type, type_b: Type) -> Type {
             }
         }
 
+        // Predicate types unify if they have the same name.
+        // If they are diffferent then the union is ExtendedJSON.
+        (
+            Type::Predicate {
+                object_type_name: object_a,
+            },
+            Type::Predicate {
+                object_type_name: object_b,
+            },
+        ) => {
+            if object_a == object_b {
+                Type::Predicate {
+                    object_type_name: object_a,
+                }
+            } else {
+                Type::ExtendedJSON
+            }
+        }
+
         // Array types unify iff their element types unify.
         (Type::ArrayOf(elem_type_a), Type::ArrayOf(elem_type_b)) => {
             let elem_type = unify_type(*elem_type_a, *elem_type_b);

--- a/crates/cli/src/native_query/aggregation_expression.rs
+++ b/crates/cli/src/native_query/aggregation_expression.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use itertools::{Either, Itertools as _};
+use itertools::Itertools as _;
 use mongodb::bson::{Bson, Document};
 use mongodb_support::BsonScalarType;
 use nonempty::NonEmpty;
@@ -341,10 +341,10 @@ pub fn infer_type_from_reference_shorthand(
             name,
             type_annotation,
         } => {
-            let constraints = match type_annotation {
-                Some(annotation) => Either::Left(std::iter::once(TypeConstraint::from(annotation))),
-                None => Either::Right(type_hint.into_iter().cloned()),
-            };
+            let constraints = type_hint
+                .into_iter()
+                .cloned()
+                .chain(type_annotation.map(TypeConstraint::from));
             context.register_parameter(name.into(), constraints)
         }
         Reference::PipelineVariable { .. } => todo!("pipeline variable"),

--- a/crates/cli/src/native_query/error.rs
+++ b/crates/cli/src/native_query/error.rs
@@ -78,9 +78,6 @@ pub enum Error {
     #[error("Error parsing a string in the aggregation pipeline: {0}")]
     UnableToParseReferenceShorthand(String),
 
-    #[error("Error parsing parameter type annotation: {0}")]
-    UnableToParseTypeAnnotation(String),
-
     #[error("Type inference is not currently implemented for the query document operator, {0}. Please file a bug report, and declare types for your native query by hand for the time being.")]
     UnknownMatchDocumentOperator(String),
 

--- a/crates/cli/src/native_query/error.rs
+++ b/crates/cli/src/native_query/error.rs
@@ -55,9 +55,12 @@ pub enum Error {
         field_name: FieldName,
     },
 
-    #[error("Type mismatch in {context}: {a:?} is not compatible with {b:?}")]
+    #[error("Type mismatch{}: {a:?} is not compatible with {b:?}", match context {
+        Some(context) => format!(" in {}", context),
+        None => String::new(),
+    })]
     TypeMismatch {
-        context: String,
+        context: Option<String>,
         a: TypeConstraint,
         b: TypeConstraint,
     },
@@ -114,7 +117,7 @@ fn unable_to_infer_types_message(
         for name in problem_parameter_types {
             message += &format!("- {name}\n");
         }
-        message += "\nTry adding type annotations of the form: {{parameter_name|[int!]!}}\n";
+        message += "\nTry adding type annotations of the form: {{ parameter_name | [int!]! }}\n";
     }
     if could_not_infer_return_type {
         message += "\nUnable to infer return type.";

--- a/crates/cli/src/native_query/error.rs
+++ b/crates/cli/src/native_query/error.rs
@@ -78,6 +78,9 @@ pub enum Error {
     #[error("Error parsing a string in the aggregation pipeline: {0}")]
     UnableToParseReferenceShorthand(String),
 
+    #[error("Error parsing parameter type annotation: {0}")]
+    UnableToParseTypeAnnotation(String),
+
     #[error("Type inference is not currently implemented for the query document operator, {0}. Please file a bug report, and declare types for your native query by hand for the time being.")]
     UnknownMatchDocumentOperator(String),
 

--- a/crates/cli/src/native_query/error.rs
+++ b/crates/cli/src/native_query/error.rs
@@ -9,7 +9,7 @@ use super::type_constraint::{ObjectTypeConstraint, TypeConstraint, TypeVariable}
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, PartialEq)]
 pub enum Error {
     #[error("Cannot infer a result type for an empty pipeline")]
     EmptyPipeline,

--- a/crates/cli/src/native_query/error.rs
+++ b/crates/cli/src/native_query/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
         field_name: FieldName,
     },
 
-    #[error("Type mismatch{}: {a:?} is not compatible with {b:?}", match context {
+    #[error("Type mismatch{}: {a} is not compatible with {b}", match context {
         Some(context) => format!(" in {}", context),
         None => String::new(),
     })]
@@ -118,6 +118,7 @@ fn unable_to_infer_types_message(
             message += &format!("- {name}\n");
         }
         message += "\nTry adding type annotations of the form: {{ parameter_name | [int!]! }}\n";
+        message += "\nIf you added an annotation, and you are still seeing this error then the type you gave may not be compatible with the context where the parameter is used.\n";
     }
     if could_not_infer_return_type {
         message += "\nUnable to infer return type.";

--- a/crates/cli/src/native_query/mod.rs
+++ b/crates/cli/src/native_query/mod.rs
@@ -5,6 +5,7 @@ mod pipeline;
 mod pipeline_type_context;
 mod prune_object_types;
 mod reference_shorthand;
+mod type_annotation;
 mod type_constraint;
 mod type_solver;
 

--- a/crates/cli/src/native_query/mod.rs
+++ b/crates/cli/src/native_query/mod.rs
@@ -101,7 +101,10 @@ pub async fn run(context: &Context, command: Command) -> anyhow::Result<()> {
             let native_query =
                 match native_query_from_pipeline(&configuration, &name, collection, pipeline) {
                     Ok(q) => WithName::named(name, q),
-                    Err(_) => todo!(),
+                    Err(err) => {
+                        eprintln!("Error interpreting aggregation pipeline.\n\n{err}");
+                        exit(ExitCode::CouldNotReadAggregationPipeline.into())
+                    }
                 };
 
             let native_query_dir = native_query_path

--- a/crates/cli/src/native_query/pipeline/match_stage.rs
+++ b/crates/cli/src/native_query/pipeline/match_stage.rs
@@ -264,10 +264,8 @@ fn analyze_match_expression_string(
             name,
             type_annotation,
         } => {
-            let constraints = match type_annotation {
-                Some(type_annotation) => [type_annotation.into()],
-                None => [field_type.clone()],
-            };
+            let constraints = std::iter::once(field_type.clone())
+                .chain(type_annotation.map(TypeConstraint::from));
             context.register_parameter(name.into(), constraints);
         }
         Reference::String {

--- a/crates/cli/src/native_query/pipeline/match_stage.rs
+++ b/crates/cli/src/native_query/pipeline/match_stage.rs
@@ -262,9 +262,13 @@ fn analyze_match_expression_string(
     match parse_reference_shorthand(&match_expression)? {
         Reference::NativeQueryVariable {
             name,
-            type_annotation: _, // TODO: parse type annotation ENG-1249
+            type_annotation,
         } => {
-            context.register_parameter(name.into(), [field_type.clone()]);
+            let constraints = match type_annotation {
+                Some(type_annotation) => [type_annotation.into()],
+                None => [field_type.clone()],
+            };
+            context.register_parameter(name.into(), constraints);
         }
         Reference::String {
             native_query_variables,

--- a/crates/cli/src/native_query/reference_shorthand.rs
+++ b/crates/cli/src/native_query/reference_shorthand.rs
@@ -3,11 +3,12 @@ use ndc_models::FieldName;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
-    character::complete::{alpha1, alphanumeric1},
+    character::complete::{alpha1, alphanumeric1, multispace0},
     combinator::{all_consuming, cut, map, opt, recognize},
+    error::ParseError,
     multi::{many0, many0_count},
     sequence::{delimited, pair, preceded},
-    IResult,
+    IResult, Parser,
 };
 
 use super::{
@@ -70,11 +71,11 @@ fn native_query_variable(input: &str) -> IResult<&str, Reference> {
             content.trim()
         })(input)
     };
-    let type_annotation = preceded(tag("|"), type_expression);
+    let type_annotation = preceded(ws(tag("|")), type_expression);
 
     let (remaining, (name, variable_type)) = delimited(
         tag("{{"),
-        cut(pair(placeholder_content, opt(type_annotation))),
+        cut(ws(pair(ws(placeholder_content), ws(opt(type_annotation))))),
         tag("}}"),
     )(input)?;
     // Since the native_query_variable parser runs inside an `alt`, the use of `cut` commits to
@@ -138,4 +139,15 @@ fn plain_string(_input: &str) -> IResult<&str, Reference> {
             native_query_variables: Default::default(),
         },
     ))
+}
+
+/// A combinator that takes a parser `inner` and produces a parser that also consumes both leading and
+/// trailing whitespace, returning the output of `inner`.
+///
+/// From https://github.com/rust-bakery/nom/blob/main/doc/nom_recipes.md#wrapper-combinators-that-eat-whitespace-before-and-after-a-parser
+fn ws<'a, O, E: ParseError<&'a str>, F>(inner: F) -> impl Parser<&'a str, O, E>
+where
+    F: Parser<&'a str, O, E>,
+{
+    delimited(multispace0, inner, multispace0)
 }

--- a/crates/cli/src/native_query/tests.rs
+++ b/crates/cli/src/native_query/tests.rs
@@ -198,7 +198,7 @@ fn emits_error_on_incorrect_parameter_type_annotation() -> googletest::Result<()
     expect_that!(
         native_query,
         err(displays_as(contains_substring(
-            "string is not compatible with decimal"
+            "string! is not compatible with decimal"
         )))
     );
     Ok(())

--- a/crates/cli/src/native_query/tests.rs
+++ b/crates/cli/src/native_query/tests.rs
@@ -15,7 +15,7 @@ use mongodb_support::{
     aggregate::{Accumulator, Pipeline, Selection, Stage},
     BsonScalarType,
 };
-use ndc_models::{FieldName, ObjectTypeName};
+use ndc_models::{ArgumentName, FieldName, ObjectTypeName};
 use pretty_assertions::assert_eq;
 use test_helpers::configuration::mflix_config;
 

--- a/crates/cli/src/native_query/tests.rs
+++ b/crates/cli/src/native_query/tests.rs
@@ -15,7 +15,7 @@ use mongodb_support::{
     aggregate::{Accumulator, Pipeline, Selection, Stage},
     BsonScalarType,
 };
-use ndc_models::{FieldName, ObjectTypeName};
+use ndc_models::{ArgumentName, FieldName, ObjectTypeName};
 use pretty_assertions::assert_eq;
 use test_helpers::configuration::mflix_config;
 
@@ -152,6 +152,32 @@ fn infers_native_query_from_pipeline_with_unannotated_parameter() -> googletest:
             field!(
                 ObjectField.r#type,
                 eq(&Type::Scalar(BsonScalarType::String))
+            )
+        )]
+    );
+    Ok(())
+}
+
+#[googletest::test]
+fn reads_parameter_type_annotation() -> googletest::Result<()> {
+    let config = mflix_config();
+
+    let pipeline = Pipeline::new(vec![Stage::Match(doc! {
+        "title": { "$eq": "{{ title | decimal }}" },
+    })]);
+
+    let native_query =
+        native_query_from_pipeline(&config, "movies_by_title", Some("movies".into()), pipeline)?;
+
+    expect_that!(
+        native_query.arguments,
+        unordered_elements_are![(
+            eq(&ArgumentName::from("title")),
+            field!(
+                ObjectField.r#type,
+                eq(&Type::Nullable(Box::new(Type::Scalar(
+                    BsonScalarType::Decimal
+                ))))
             )
         )]
     );
@@ -391,7 +417,10 @@ fn supports_project_stage_in_inclusion_mode() -> Result<()> {
     let native_query =
         native_query_from_pipeline(&config, "inclusion", Some("movies".into()), pipeline)?;
 
-    expect_eq!(native_query.result_document_type, "inclusion_project".into());
+    expect_eq!(
+        native_query.result_document_type,
+        "inclusion_project".into()
+    );
 
     expect_eq!(
         native_query.object_types,
@@ -402,7 +431,10 @@ fn supports_project_stage_in_inclusion_mode() -> Result<()> {
                     fields: object_fields([
                         ("_id", Type::Scalar(BsonScalarType::ObjectId)),
                         ("title", Type::Scalar(BsonScalarType::String)),
-                        ("tomatoes", Type::Object("inclusion_project_tomatoes".into())),
+                        (
+                            "tomatoes",
+                            Type::Object("inclusion_project_tomatoes".into())
+                        ),
                         ("releaseDate", Type::Scalar(BsonScalarType::Date)),
                     ]),
                     description: None

--- a/crates/cli/src/native_query/type_annotation.rs
+++ b/crates/cli/src/native_query/type_annotation.rs
@@ -124,7 +124,7 @@ where
 /// trailing whitespace, returning the output of `inner`.
 ///
 /// From https://github.com/rust-bakery/nom/blob/main/doc/nom_recipes.md#wrapper-combinators-that-eat-whitespace-before-and-after-a-parser
-pub fn ws<'a, O, E: ParseError<&'a str>, F>(inner: F) -> impl Parser<&'a str, O, E>
+fn ws<'a, O, E: ParseError<&'a str>, F>(inner: F) -> impl Parser<&'a str, O, E>
 where
     F: Parser<&'a str, O, E>,
 {

--- a/crates/cli/src/native_query/type_annotation.rs
+++ b/crates/cli/src/native_query/type_annotation.rs
@@ -1,38 +1,30 @@
 use configuration::schema::Type;
 use enum_iterator::all;
+use itertools::Itertools;
 use mongodb_support::BsonScalarType;
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::{alpha1, alphanumeric1},
-    combinator::{all_consuming, cut, opt, recognize},
+    combinator::{cut, opt, recognize},
     error::ParseError,
     multi::many0_count,
     sequence::{delimited, pair, preceded},
     IResult, Parser,
 };
 
-use super::error::{Error, Result};
-
-/// Parse a type expression according to GraphQL syntax, using MongoDB scalar type names.
+/// Nom parser for type expressions Parse a type expression according to GraphQL syntax, using
+/// MongoDB scalar type names.
 ///
 /// This implies that types are nullable by default unless they use the non-nullable suffix (!).
-pub fn parse_type_annotation(input: &str) -> Result<Type> {
-    match type_expression(input) {
-        Ok((_, r)) => Ok(r),
-        Err(err) => Err(Error::UnableToParseTypeAnnotation(format!("{err}"))),
-    }
-}
-
-/// Nom parser for type expressions
 pub fn type_expression(input: &str) -> IResult<&str, Type> {
-    all_consuming(nullability_suffix(alt((
+    nullability_suffix(alt((
         extended_json_annotation,
         scalar_annotation,
         predicate_annotation,
         object_annotation, // object_annotation must follow parsers that look for fixed sets of keywords
         array_of_annotation,
-    ))))(input)
+    )))(input)
 }
 
 fn extended_json_annotation(input: &str) -> IResult<&str, Type> {
@@ -41,9 +33,13 @@ fn extended_json_annotation(input: &str) -> IResult<&str, Type> {
 }
 
 fn scalar_annotation(input: &str) -> IResult<&str, Type> {
+    // This parser takes the first type name that matches so in cases where one type name is
+    // a prefix of another we must try the longer name first. Otherwise `javascriptWithScope` can
+    // be mistaken for the type `javascript`. So we sort type names by length in descending order.
     let scalar_type_parsers = all::<BsonScalarType>()
+        .sorted_by_key(|t| 1000 - t.bson_name().len())
         .map(|t| tag(t.bson_name()).map(move |_| Type::Nullable(Box::new(Type::Scalar(t)))));
-    all_consuming(alt_many(scalar_type_parsers))(input)
+    alt_many(scalar_type_parsers)(input)
 }
 
 fn object_annotation(input: &str) -> IResult<&str, Type> {
@@ -74,7 +70,11 @@ fn object_type_name(input: &str) -> IResult<&str, &str> {
 }
 
 fn array_of_annotation(input: &str) -> IResult<&str, Type> {
-    delimited(tag("["), cut(type_expression), tag("]"))(input)
+    let (remaining, element_type) = delimited(tag("["), cut(type_expression), tag("]"))(input)?;
+    Ok((
+        remaining,
+        Type::Nullable(Box::new(Type::ArrayOf(Box::new(element_type)))),
+    ))
 }
 
 /// The other parsers produce nullable types by default. This wraps a parser that produces a type,
@@ -86,6 +86,7 @@ where
 {
     move |input| {
         let (remaining, t) = parser.parse(input)?;
+        let t = t.normalize_type(); // strip redundant nullable layers
         let (remaining, non_nullable_suffix) = opt(tag("!"))(remaining)?;
         let t = match non_nullable_suffix {
             None => t,
@@ -102,7 +103,7 @@ where
 /// a tuple.
 ///
 /// From https://stackoverflow.com/a/76759023/103017
-pub fn alt_many<I, O, E, P, Ps>(mut parsers: Ps) -> impl Parser<I, O, E>
+pub fn alt_many<I, O, E, P, Ps>(mut parsers: Ps) -> impl FnMut(I) -> IResult<I, O, E>
 where
     P: Parser<I, O, E>,
     I: Clone,
@@ -121,14 +122,42 @@ where
 
 #[cfg(test)]
 mod tests {
+    use configuration::schema::Type;
+    use googletest::prelude::*;
+    use mongodb_support::BsonScalarType;
     use proptest::{prop_assert_eq, proptest};
     use test_helpers::arb_type;
 
+    #[googletest::test]
+    fn parses_scalar_type_expression() -> Result<()> {
+        expect_that!(
+            super::type_expression("double"),
+            ok((
+                anything(),
+                eq(&Type::Nullable(Box::new(Type::Scalar(
+                    BsonScalarType::Double
+                ))))
+            ))
+        );
+        Ok(())
+    }
+
+    #[googletest::test]
+    fn parses_non_nullable_suffix() -> Result<()> {
+        expect_that!(
+            super::type_expression("double!"),
+            ok((anything(), eq(&Type::Scalar(BsonScalarType::Double))))
+        );
+        Ok(())
+    }
+
     proptest! {
         #[test]
-        fn test_parse_type_annotation(t in arb_type()) {
+        fn type_expression_roundtrips_display_and_parsing(t in arb_type()) {
+            let t = t.normalize_type();
             let annotation = t.to_string();
-            let parsed = super::parse_type_annotation(&annotation);
+            println!("annotation: {}", annotation);
+            let (_, parsed) = super::type_expression(&annotation)?;
             prop_assert_eq!(parsed, t)
         }
     }

--- a/crates/cli/src/native_query/type_annotation.rs
+++ b/crates/cli/src/native_query/type_annotation.rs
@@ -1,0 +1,135 @@
+use configuration::schema::Type;
+use enum_iterator::all;
+use mongodb_support::BsonScalarType;
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    character::complete::{alpha1, alphanumeric1},
+    combinator::{all_consuming, cut, opt, recognize},
+    error::ParseError,
+    multi::many0_count,
+    sequence::{delimited, pair, preceded},
+    IResult, Parser,
+};
+
+use super::error::{Error, Result};
+
+/// Parse a type expression according to GraphQL syntax, using MongoDB scalar type names.
+///
+/// This implies that types are nullable by default unless they use the non-nullable suffix (!).
+pub fn parse_type_annotation(input: &str) -> Result<Type> {
+    match type_expression(input) {
+        Ok((_, r)) => Ok(r),
+        Err(err) => Err(Error::UnableToParseTypeAnnotation(format!("{err}"))),
+    }
+}
+
+/// Nom parser for type expressions
+pub fn type_expression(input: &str) -> IResult<&str, Type> {
+    all_consuming(nullability_suffix(alt((
+        extended_json_annotation,
+        scalar_annotation,
+        predicate_annotation,
+        object_annotation, // object_annotation must follow parsers that look for fixed sets of keywords
+        array_of_annotation,
+    ))))(input)
+}
+
+fn extended_json_annotation(input: &str) -> IResult<&str, Type> {
+    let (remaining, _) = tag("extendedJSON")(input)?;
+    Ok((remaining, Type::ExtendedJSON))
+}
+
+fn scalar_annotation(input: &str) -> IResult<&str, Type> {
+    let scalar_type_parsers = all::<BsonScalarType>()
+        .map(|t| tag(t.bson_name()).map(move |_| Type::Nullable(Box::new(Type::Scalar(t)))));
+    all_consuming(alt_many(scalar_type_parsers))(input)
+}
+
+fn object_annotation(input: &str) -> IResult<&str, Type> {
+    let (remaining, name) = object_type_name(input)?;
+    Ok((
+        remaining,
+        Type::Nullable(Box::new(Type::Object(name.into()))),
+    ))
+}
+
+fn predicate_annotation(input: &str) -> IResult<&str, Type> {
+    let (remaining, name) = preceded(
+        tag("predicate"),
+        delimited(tag("<"), cut(object_type_name), tag(">")),
+    )(input)?;
+    Ok((
+        remaining,
+        Type::Nullable(Box::new(Type::Predicate {
+            object_type_name: name.into(),
+        })),
+    ))
+}
+
+fn object_type_name(input: &str) -> IResult<&str, &str> {
+    let first_char = alt((alpha1, tag("_")));
+    let succeeding_char = alt((alphanumeric1, tag("_")));
+    recognize(pair(first_char, many0_count(succeeding_char)))(input)
+}
+
+fn array_of_annotation(input: &str) -> IResult<&str, Type> {
+    delimited(tag("["), cut(type_expression), tag("]"))(input)
+}
+
+/// The other parsers produce nullable types by default. This wraps a parser that produces a type,
+/// and flips the type from nullable to non-nullable if it sees the non-nullable suffix (!).
+fn nullability_suffix<'a, P, E>(mut parser: P) -> impl FnMut(&'a str) -> IResult<&'a str, Type, E>
+where
+    P: Parser<&'a str, Type, E> + 'a,
+    E: ParseError<&'a str>,
+{
+    move |input| {
+        let (remaining, t) = parser.parse(input)?;
+        let (remaining, non_nullable_suffix) = opt(tag("!"))(remaining)?;
+        let t = match non_nullable_suffix {
+            None => t,
+            Some(_) => match t {
+                Type::Nullable(t) => *t,
+                t => t,
+            },
+        };
+        Ok((remaining, t))
+    }
+}
+
+/// Like [nom::branch::alt], but accepts a dynamically-constructed iterable of parsers instead of
+/// a tuple.
+///
+/// From https://stackoverflow.com/a/76759023/103017
+pub fn alt_many<I, O, E, P, Ps>(mut parsers: Ps) -> impl Parser<I, O, E>
+where
+    P: Parser<I, O, E>,
+    I: Clone,
+    for<'a> &'a mut Ps: IntoIterator<Item = P>,
+    E: ParseError<I>,
+{
+    move |input: I| {
+        for mut parser in &mut parsers {
+            if let r @ Ok(_) = parser.parse(input.clone()) {
+                return r;
+            }
+        }
+        nom::combinator::fail::<I, O, E>(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{prop_assert_eq, proptest};
+    use test_helpers::arb_type;
+
+    proptest! {
+        #[test]
+        fn test_parse_type_annotation(t in arb_type()) {
+            let annotation = t.to_string();
+            let parsed = super::parse_type_annotation(&annotation);
+            prop_assert_eq!(parsed, t)
+        }
+    }
+}

--- a/crates/cli/src/native_query/type_constraint.rs
+++ b/crates/cli/src/native_query/type_constraint.rs
@@ -54,7 +54,6 @@ pub enum TypeConstraint {
     },
 
     // Complex types
-    
     Union(BTreeSet<TypeConstraint>),
 
     /// Unlike Union we expect the solved concrete type for a variable with a OneOf constraint may
@@ -93,15 +92,15 @@ pub enum TypeConstraint {
 impl std::fmt::Display for TypeConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TypeConstraint::ExtendedJSON => write!(f, "ExtendedJSON"),
+            TypeConstraint::ExtendedJSON => write!(f, "extendedJSON"),
             TypeConstraint::Scalar(s) => s.fmt(f),
-            TypeConstraint::Object(name) => write!(f, "Object({name})"),
+            TypeConstraint::Object(name) => write!(f, "{name}"),
             TypeConstraint::ArrayOf(t) => write!(f, "[{t}]"),
             TypeConstraint::Predicate { object_type_name } => {
-                write!(f, "Predicate({object_type_name})")
+                write!(f, "predicate<{object_type_name}>")
             }
-            TypeConstraint::Union(ts) => write!(f, "{}", ts.iter().join(" | ")),
-            TypeConstraint::OneOf(ts) => write!(f, "{}", ts.iter().join(" / ")),
+            TypeConstraint::Union(ts) => write!(f, "({})", ts.iter().join(" | ")),
+            TypeConstraint::OneOf(ts) => write!(f, "({})", ts.iter().join(" / ")),
             TypeConstraint::Variable(v) => v.fmt(f),
             TypeConstraint::ElementOf(t) => write!(f, "{t}[@]"),
             TypeConstraint::FieldOf { target_type, path } => {

--- a/crates/cli/src/native_query/type_solver/simplify.rs
+++ b/crates/cli/src/native_query/type_solver/simplify.rs
@@ -633,6 +633,34 @@ mod tests {
     }
 
     #[googletest::test]
+    fn simplifies_from_nullable_to_non_nullable_in_contravariant_context() -> Result<()> {
+        let configuration = mflix_config();
+        let result = super::simplify_constraints(
+            &configuration,
+            &Default::default(),
+            &mut Default::default(),
+            Some(TypeVariable::new(1, Variance::Contravariant)),
+            [
+                TypeConstraint::Scalar(BsonScalarType::String),
+                TypeConstraint::Union(
+                    [
+                        TypeConstraint::Scalar(BsonScalarType::String),
+                        TypeConstraint::Scalar(BsonScalarType::Null),
+                    ]
+                    .into(),
+                ),
+            ],
+        );
+        expect_that!(
+            result,
+            ok(eq(&BTreeSet::from([TypeConstraint::Scalar(
+                BsonScalarType::String
+            )])))
+        );
+        Ok(())
+    }
+
+    #[googletest::test]
     fn emits_error_if_scalar_is_not_compatible_with_any_union_branch() -> Result<()> {
         let configuration = mflix_config();
         let result = super::simplify_constraints(

--- a/crates/cli/src/native_query/type_solver/simplify.rs
+++ b/crates/cli/src/native_query/type_solver/simplify.rs
@@ -697,4 +697,43 @@ mod tests {
         );
         Ok(())
     }
+
+    // TODO:
+    // #[googletest::test]
+    // fn simplifies_two_compatible_unions_in_contravariant_context() -> Result<()> {
+    //     let configuration = mflix_config();
+    //     let result = super::simplify_constraints(
+    //         &configuration,
+    //         &Default::default(),
+    //         &mut Default::default(),
+    //         Some(TypeVariable::new(1, Variance::Contravariant)),
+    //         [
+    //             TypeConstraint::Union(
+    //                 [
+    //                     TypeConstraint::Scalar(BsonScalarType::Double),
+    //                     TypeConstraint::Scalar(BsonScalarType::Null),
+    //                 ]
+    //                 .into(),
+    //             ),
+    //             TypeConstraint::Union(
+    //                 [
+    //                     TypeConstraint::Scalar(BsonScalarType::Int),
+    //                     TypeConstraint::Scalar(BsonScalarType::Null),
+    //                 ]
+    //                 .into(),
+    //             ),
+    //         ],
+    //     );
+    //     expect_that!(
+    //         result,
+    //         ok(eq(&BTreeSet::from([TypeConstraint::Union(
+    //             [
+    //                 TypeConstraint::Scalar(BsonScalarType::Int),
+    //                 TypeConstraint::Scalar(BsonScalarType::Null),
+    //             ]
+    //             .into(),
+    //         )])))
+    //     );
+    //     Ok(())
+    // }
 }

--- a/crates/configuration/src/schema/mod.rs
+++ b/crates/configuration/src/schema/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Display};
 
 use ref_cast::RefCast as _;
 use schemars::JsonSchema;
@@ -120,6 +120,31 @@ impl From<ndc_models::Type> for Type {
             }
             ndc_models::Type::Predicate { object_type_name } => {
                 Type::Predicate { object_type_name }
+            }
+        }
+    }
+}
+
+impl Display for Type {
+    /// Display types using GraphQL-style syntax
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn helper(t: &Type, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match t {
+                Type::ExtendedJSON => write!(f, "extendedJSON"),
+                Type::Scalar(s) => write!(f, "{}", s.bson_name()),
+                Type::Object(name) => write!(f, "{name}"),
+                Type::ArrayOf(t) => write!(f, "[{t}]"),
+                Type::Nullable(t) => write!(f, "{t}"),
+                Type::Predicate { object_type_name } => {
+                    write!(f, "predicate<{object_type_name}>")
+                }
+            }
+        }
+        match self {
+            Type::Nullable(t) => helper(t, f),
+            t => {
+                helper(t, f)?;
+                write!(f, "!")
             }
         }
     }

--- a/crates/test-helpers/src/arb_type.rs
+++ b/crates/test-helpers/src/arb_type.rs
@@ -1,7 +1,7 @@
 use configuration::schema::Type;
 use enum_iterator::Sequence as _;
 use mongodb_support::BsonScalarType;
-use proptest::prelude::*;
+use proptest::{prelude::*, string::string_regex};
 
 pub fn arb_bson_scalar_type() -> impl Strategy<Value = BsonScalarType> {
     (0..BsonScalarType::CARDINALITY)
@@ -11,7 +11,10 @@ pub fn arb_bson_scalar_type() -> impl Strategy<Value = BsonScalarType> {
 pub fn arb_type() -> impl Strategy<Value = Type> {
     let leaf = prop_oneof![
         arb_bson_scalar_type().prop_map(Type::Scalar),
-        any::<String>().prop_map(Type::Object)
+        arb_object_type_name().prop_map(Type::Object),
+        arb_object_type_name().prop_map(|name| Type::Predicate {
+            object_type_name: name.into()
+        })
     ];
     leaf.prop_recursive(3, 10, 10, |inner| {
         prop_oneof![
@@ -19,4 +22,13 @@ pub fn arb_type() -> impl Strategy<Value = Type> {
             inner.prop_map(|t| Type::Nullable(Box::new(t)))
         ]
     })
+}
+
+fn arb_object_type_name() -> impl Strategy<Value = String> {
+    string_regex(r#"[a-zA-Z_][a-zA-Z0-9_]*"#)
+        .unwrap()
+        .prop_filter(
+            "object type names must not collide with scalar type names",
+            |name| !enum_iterator::all::<BsonScalarType>().any(|t| t.bson_name() == name),
+        )
 }


### PR DESCRIPTION
This is work an an in-progress feature that is gated behind a feature flag, `native-query-subcommand`.

Parses type annotations in placeholders that reference native query parameters. We already have an error message suggesting doing this, now the system actually reads these. For example,

```json
{
  "$match": {
    "imdb.rating": { "$gt": "{{ min_rating | int! }}" }
  }
}
```

The generated query for that configuration includes a parameter named `min_rating` with type `int`. Without the annotation it would have inferred `double`.

Type annotations are checked against the inferred type for the position so you will see errors if the annotated type is not compatible. Parameters are treated as contravariant so you can only provide a subtype of the inferred type - for example you can constrain a parameter type to be non-nullable even if it is in a nullable context. There are cases where the type checker cannot infer a type in which case annotations are necessary.

I know we already have a similar parser for type expressions in hml files. I thought it would be easier to write a new one specialized for this connector and for MongoDB scalar types since it's about 100 LOC.

Type expressions use GraphQL syntax to match types as seen in GraphQL and in hml. There is one addition: I invented a syntax for predicate types, `predicate<ObjectTypeName>`. The parser happens to be written so that if the angle brackets are absent the word `predicate` will be interpreted as an object type so we don't have a problem if a user want to use an object type named "predicate".

On the other hand this parser does not allow object type names that match MongoDB scalar type names.

While I was working on this I noticed some issues with unifying types in the presence of nullability, and with displaying errors when a type annotation can't be unified with inferred constraints for a parameter's context. So I included some fixes in those areas.