### PR TITLE
Remove volume from dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog documents the changes between release versions.
 ### Fixed
 
 - The connector previously used Cloudflare's DNS resolver. Now it uses the locally-configured DNS resolver. ([#125](https://github.com/hasura/ndc-mongodb/pull/125))
+- Fixed connector not picking up configuration changes when running locally using the ddn CLI workflow. ([#133](https://github.com/hasura/ndc-mongodb/pull/133))
 
 #### Managing native queries with the CLI
 

--- a/nix/docker-connector.nix
+++ b/nix/docker-connector.nix
@@ -29,9 +29,6 @@ let
         "OTEL_SERVICE_NAME=mongodb-connector"
         "OTEL_EXPORTER_OTLP_ENDPOINT=${default-otlp-endpoint}"
       ];
-      Volumes = {
-        "${config-directory}" = { };
-      };
     } // extraConfig;
   };
 in


### PR DESCRIPTION
Setting the volumn in the dockerfile is causing issues during local development where the volumn gets created and then not updated when you reintrospect or change the configuration.json file.

- [x] TODO: Update Changelog file