### PR TITLE
fix security vulnerability RUSTSEC-2024-0421

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ This changelog documents the changes between release versions.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade dependencies to get fix for RUSTSEC-2024-0421, a vulnerability in domain name comparisons ([#138](https://github.com/hasura/ndc-mongodb/pull/138))
+
+#### Fix for RUSTSEC-2024-0421 / CVE-2024-12224
+
+Updates dependencies to upgrade the library, idna, to get a version that is not
+affected by a vulnerability reported in [RUSTSEC-2024-0421][].
+
+[RUSTSEC-2024-0421]: https://rustsec.org/advisories/RUSTSEC-2024-0421
+
+The vulnerability allows an attacker to craft a domain name that older versions
+of idna interpret as identical to a legitimate domain name, but that is in fact
+a different name. We do not expect that this impacts the MongoDB connector since
+it uses the affected library exclusively to connect to MongoDB databases, and
+database URLs are supplied by trusted administrators. But better to be safe than
+sorry.
+
 ## [1.5.0] - 2024-12-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+checksum = "447afdcdb8afb9d0a852af6dc65d9b285ce720ed7a59e42a8bf2e931c67bc1b5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1043,7 +1043,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "idna 0.4.0",
+ "idna",
  "ipnet",
  "once_cell",
  "rand",
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1420,16 +1420,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
 
 [[package]]
 name = "idna"
@@ -3770,7 +3760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.0",
+ "idna",
  "percent-encoding",
 ]
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -305,7 +305,7 @@ It's important to keep the GraphQL Engine version updated to make sure that the
 connector is working with the latest engine version. To update run,
 
 ```sh
-$ nix flake lock --update-input graphql-engine-source
+$ nix flake update graphql-engine-source
 ```
 
 Then commit the changes to `flake.lock` to version control.
@@ -332,7 +332,7 @@ any order):
 To update `rust-overlay` run,
 
 ```sh
-$ nix flake lock --update-input rust-overlay
+$ nix flake update rust-overlay
 ```
 
 If you are using direnv to automatically apply the nix dev environment note that

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
     # If source changes aren't picked up automatically try:
     #
     # - committing changes to the local engine repo
-    # - running `nix flake lock --update-input graphql-engine-source` in this repo
+    # - running `nix flake update graphql-engine-source` in this repo
     # - arion up -d engine
     #
     graphql-engine-source = {


### PR DESCRIPTION
[RUSTSEC-2024-0421][] reports a vulnerability in the crate idna which is a dependency of a dependency of the mongodb rust driver. Specifically it interprets non-ASCII characters in domain names.

[RUSTSEC-2024-0421]: https://rustsec.org/advisories/RUSTSEC-2024-0421

This change updates `Cargo.lock` to update two direct dependencies of the mongodb driver, hickory-proto and hickory-resolver from v0.24.1 to v0.24.2. That in turn updates the dependency on idna from v0.4 to v1.0.0 which is not affected by RUSTSEC-2024-0421. There are also a couple of small documentation updates here that are not relevant to the security fix, but that I want to get in. Those changes switch from a deprecated form of the `nix flake` command to the newer syntax.

MongoDB has [an upstream fix](https://github.com/mongodb/mongo-rust-driver/commit/31ae5a2039f1b56e199b09381730d4f9facd7fa2) for the driver which makes the same change: bumping the hickory dependencies to v0.24.2. That fix was made this morning, and is not available in the latest driver release which as of this writing is v3.1.0.

The vulnerability allows an attacker to craft a domain name that older versions of idna interpret as identical to a legitimate domain name, but that is in fact a different name. I think this does not impact the MongoDB connector since it uses the affected library exclusively to connect to MongoDB databases, and database URLs are supplied by trusted administrators. But best to get the fix anyway.