### PR TITLE
fix deploy automation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   binary:
     name: deploy::binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v3
@@ -42,7 +42,7 @@ jobs:
   docker:
     name: deploy::docker
     needs: binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v3
@@ -63,6 +63,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    # This setting is necessary as of the ubuntu-24.04 runner. 
+    # See https://github.com/actions/runner-images/issues/10443
+    - name: Enable user namespace remapping
+      run: |
+          echo "kernel.unprivileged_userns_clone=1" | sudo tee /etc/sysctl.conf
+          sudo sysctl -p
+
     - name: Deploy 🚀
       run: nix run .#publish-docker-image ${{ github.ref }}
 
@@ -70,7 +77,7 @@ jobs:
     # For now, only run on tagged releases because main builds generate a Docker image tag name that
     # is not easily accessible here
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -93,11 +100,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             rustflags: -C target-feature=+crt-static
             linux-packages: musl-tools
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             rustflags: -C target-feature=+crt-static
             linux-packages: gcc-aarch64-linux-gnu musl-tools
@@ -185,7 +192,7 @@ jobs:
       - docker
       - connector-definition
       - build-cli-binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,10 @@ jobs:
   docker:
     name: deploy::docker
     needs: binary
-    runs-on: ubuntu-24.04
+
+    # This job doesn't work as written on ubuntu-24.04. The problem is described
+    # in this issue: https://github.com/actions/runner-images/issues/10443
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v3
@@ -63,13 +66,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    # This setting is necessary as of the ubuntu-24.04 runner. 
-    # See https://github.com/actions/runner-images/issues/10443
-    - name: Enable user namespace remapping
-      run: |
-          echo "kernel.unprivileged_userns_clone=1" | sudo tee /etc/sysctl.conf
-          sudo sysctl -p
 
     - name: Deploy 🚀
       run: nix run .#publish-docker-image ${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - jessehallett/fix-deploy-automation # for testing changes
+      - fix-deploy-automation # for testing changes
     tags:
       - 'v*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix-deploy-automation # for testing changes
     tags:
       - 'v*'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - jessehallett/fix-deploy-automation # for testing changes
     tags:
       - 'v*'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3


### PR DESCRIPTION
Since the last release the `ubuntu-latest` runner for this repo switched from `ubuntu-22.04` to `ubuntu-24.04`. That came with changes to docker permissions configuration that broke the `deploy::docker` job. The problem is the same one described here:

https://github.com/actions/runner-images/issues/10443

Except that instead of `skopeo copy` we hit the error running `buildah`.

I've worked around the problem by rolling the `deploy::docker` job back to the `ubuntu-22.04` runner. To head off similar future issues I've changed the runners for all other jobs to a fixed runner version.