### PR TITLE
implement count aggregates for group by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog documents the changes between release versions.
 
 ### Added
 
-- You can now group documents for aggregation according to multiple grouping criteria ([#144](https://github.com/hasura/ndc-mongodb/pull/144))
+- You can now group documents for aggregation according to multiple grouping criteria ([#144](https://github.com/hasura/ndc-mongodb/pull/144), [#145](https://github.com/hasura/ndc-mongodb/pull/145))
 
 ### Changed
 
@@ -22,7 +22,7 @@ a number of improvements to the spec, and enables features that were previously
 not possible. Highlights of those new features include:
 
 - relationships can use a nested object field on the target side as a join key
-- grouping result documents, and aggregating on groups of documents (pending implementation in the mongo connector)
+- grouping result documents, and aggregating on groups of documents
 - queries on fields of nested collections (document fields that are arrays of objects)
 - filtering on scalar values inside array document fields - previously it was possible to filter on fields of objects inside arrays, but not on scalars
 

--- a/crates/cli/src/native_query/pipeline/mod.rs
+++ b/crates/cli/src/native_query/pipeline/mod.rs
@@ -211,7 +211,7 @@ fn infer_type_from_group_stage(
                 None,
                 expr.clone(),
             )?,
-            Accumulator::Push(expr) => {
+            Accumulator::AddToSet(expr) | Accumulator::Push(expr) => {
                 let t = infer_type_from_aggregation_expression(
                     context,
                     &format!("{desired_object_type_name}_push"),

--- a/crates/integration-tests/src/tests/grouping.rs
+++ b/crates/integration-tests/src/tests/grouping.rs
@@ -1,7 +1,6 @@
 use insta::assert_yaml_snapshot;
 use ndc_test_helpers::{
-    asc, binop, column_aggregate, dimension_column, field, grouping, or, ordered_dimensions, query,
-    query_request, target, value,
+    and, asc, binop, column_aggregate, column_count_aggregate, dimension_column, field, grouping, or, ordered_dimensions, query, query_request, star_count_aggregate, target, value
 };
 
 use crate::{connector::Connector, run_connector_query};
@@ -30,6 +29,35 @@ async fn runs_single_column_aggregate_on_groups() -> anyhow::Result<()> {
                                     column_aggregate("tomatoes.viewer.rating", "avg"),
                                 ),
                                 ("max_runtime", column_aggregate("runtime", "max")),
+                            ])
+                            .order_by(ordered_dimensions()),
+                    ),
+            ),
+        )
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn counts_column_values_in_groups() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request().collection("movies").query(
+                query()
+                    .predicate(and([
+                        binop("_gt", target!("year"), value!(1920)),
+                        binop("_lte", target!("year"), value!(1923)),
+                    ]))
+                    .groups(
+                        grouping()
+                            .dimensions([dimension_column("rated")])
+                            .aggregates([
+                                // The distinct count should be 3 or less because we filtered to only 3 years
+                                column_count_aggregate!("year_distinct_count" => "year", distinct: true),
+                                column_count_aggregate!("year_count" => "year", distinct: false),
+                                star_count_aggregate!("count"),
                             ])
                             .order_by(ordered_dimensions()),
                     ),

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__grouping__counts_column_values_in_groups.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__grouping__counts_column_values_in_groups.snap
@@ -1,0 +1,35 @@
+---
+source: crates/integration-tests/src/tests/grouping.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().collection(\"movies\").query(query().predicate(and([binop(\"_gt\",\ntarget!(\"year\"), value!(1920)),\nbinop(\"_lte\", target!(\"year\"),\nvalue!(1923)),])).groups(grouping().dimensions([dimension_column(\"rated\")]).aggregates([column_count_aggregate!(\"year_distinct_count\"\n=> \"year\", distinct: true),\ncolumn_count_aggregate!(\"year_count\" => \"year\", distinct: false),\nstar_count_aggregate!(\"count\"),]).order_by(ordered_dimensions()),),),).await?"
+---
+- groups:
+    - dimensions:
+        - ~
+      aggregates:
+        count: 6
+        year_count: 6
+        year_distinct_count: 3
+    - dimensions:
+        - NOT RATED
+      aggregates:
+        count: 4
+        year_count: 4
+        year_distinct_count: 3
+    - dimensions:
+        - PASSED
+      aggregates:
+        count: 3
+        year_count: 3
+        year_distinct_count: 1
+    - dimensions:
+        - TV-PG
+      aggregates:
+        count: 1
+        year_count: 1
+        year_distinct_count: 1
+    - dimensions:
+        - UNRATED
+      aggregates:
+        count: 5
+        year_count: 5
+        year_distinct_count: 2

--- a/crates/mongodb-support/src/aggregate/accumulator.rs
+++ b/crates/mongodb-support/src/aggregate/accumulator.rs
@@ -6,6 +6,12 @@ use serde::{Deserialize, Serialize};
 /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#std-label-accumulators-group
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum Accumulator {
+    /// Returns an array of unique expression values for each group. Order of the array elements is undefined.
+    ///
+    /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/addToSet/#mongodb-group-grp.-addToSet
+    #[serde(rename = "$addToSet")]
+    AddToSet(bson::Bson),
+
     /// Returns an average of numerical values. Ignores non-numeric values.
     ///
     /// See https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/#mongodb-group-grp.-avg


### PR DESCRIPTION
This completes the basic functionality for group-by started in #144  by implementing all forms of count aggregations.