### PR TITLE
unify and optimize count aggregations over grouped and ungrouped data

### DIFF
--- a/crates/integration-tests/src/tests/local_relationship.rs
+++ b/crates/integration-tests/src/tests/local_relationship.rs
@@ -1,9 +1,9 @@
 use crate::{connector::Connector, graphql_query, run_connector_query};
 use insta::assert_yaml_snapshot;
 use ndc_test_helpers::{
-    asc, binop, column, column_aggregate, dimension_column, exists, field, grouping, is_in,
-    ordered_dimensions, query, query_request, related, relation_field, relationship,
-    star_count_aggregate, target, value,
+    asc, binop, column, column_aggregate, column_count_aggregate, dimension_column, exists, field,
+    grouping, is_in, ordered_dimensions, query, query_request, related, relation_field,
+    relationship, star_count_aggregate, target, value,
 };
 use serde_json::json;
 
@@ -262,6 +262,36 @@ async fn aggregates_over_related_collection() -> anyhow::Result<()> {
                         ))
                         .fields([relation_field!("tracks" => "tracks", query().aggregates([
                           star_count_aggregate!("count"),
+                          ("average_price", column_aggregate("UnitPrice", "avg").into()),
+                        ]))])
+                        .order_by([asc!("_id")])
+                )
+                .relationships([("tracks", relationship("Track", [("AlbumId", &["AlbumId"])]))])
+        )
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn aggregates_over_empty_subset_of_related_collection() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::Chinook,
+            query_request()
+                .collection("Album")
+                .query(
+                    query()
+                        // avoid albums that are modified in mutation tests
+                        .predicate(is_in(
+                            target!("AlbumId"),
+                            [json!(15), json!(91), json!(227)]
+                        ))
+                        .fields([relation_field!("tracks" => "tracks", query()
+                          .predicate(binop("_eq", target!("Name"), value!("non-existent name")))
+                          .aggregates([
+                          star_count_aggregate!("count"),
+                          column_count_aggregate!("composer_count" => "Composer", distinct: true),
                           ("average_price", column_aggregate("UnitPrice", "avg").into()),
                         ]))])
                         .order_by([asc!("_id")])

--- a/crates/integration-tests/src/tests/local_relationship.rs
+++ b/crates/integration-tests/src/tests/local_relationship.rs
@@ -2,7 +2,8 @@ use crate::{connector::Connector, graphql_query, run_connector_query};
 use insta::assert_yaml_snapshot;
 use ndc_test_helpers::{
     asc, binop, column, column_aggregate, dimension_column, exists, field, grouping, is_in,
-    ordered_dimensions, query, query_request, related, relation_field, relationship, target, value,
+    ordered_dimensions, query, query_request, related, relation_field, relationship,
+    star_count_aggregate, target, value,
 };
 use serde_json::json;
 
@@ -239,6 +240,33 @@ async fn joins_relationships_on_nested_key() -> anyhow::Result<()> {
                     "schools_departments",
                     relationship("schools", [("_id", &["departments", "math_department_id"])])
                 )])
+        )
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn aggregates_over_related_collection() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::Chinook,
+            query_request()
+                .collection("Album")
+                .query(
+                    query()
+                        // avoid albums that are modified in mutation tests
+                        .predicate(is_in(
+                            target!("AlbumId"),
+                            [json!(15), json!(91), json!(227)]
+                        ))
+                        .fields([relation_field!("tracks" => "tracks", query().aggregates([
+                          star_count_aggregate!("count"),
+                          ("average_price", column_aggregate("UnitPrice", "avg").into()),
+                        ]))])
+                        .order_by([asc!("_id")])
+                )
+                .relationships([("tracks", relationship("Track", [("AlbumId", &["AlbumId"])]))])
         )
         .await?
     );

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__grouping__counts_column_values_in_groups.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__grouping__counts_column_values_in_groups.snap
@@ -6,30 +6,30 @@ expression: "run_connector_query(Connector::SampleMflix,\nquery_request().collec
     - dimensions:
         - ~
       aggregates:
-        count: 6
-        year_count: 6
         year_distinct_count: 3
+        year_count: 6
+        count: 6
     - dimensions:
         - NOT RATED
       aggregates:
-        count: 4
-        year_count: 4
         year_distinct_count: 3
+        year_count: 4
+        count: 4
     - dimensions:
         - PASSED
       aggregates:
-        count: 3
-        year_count: 3
         year_distinct_count: 1
+        year_count: 3
+        count: 3
     - dimensions:
         - TV-PG
       aggregates:
-        count: 1
-        year_count: 1
         year_distinct_count: 1
+        year_count: 1
+        count: 1
     - dimensions:
         - UNRATED
       aggregates:
-        count: 5
-        year_count: 5
         year_distinct_count: 2
+        year_count: 5
+        count: 5

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__aggregates_over_empty_subset_of_related_collection.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__aggregates_over_empty_subset_of_related_collection.snap
@@ -1,0 +1,20 @@
+---
+source: crates/integration-tests/src/tests/local_relationship.rs
+expression: "run_connector_query(Connector::Chinook,\nquery_request().collection(\"Album\").query(query().predicate(is_in(target!(\"AlbumId\"),\n[json!(15), json!(91),\njson!(227)])).fields([relation_field!(\"tracks\" => \"tracks\",\nquery().predicate(binop(\"_eq\", target!(\"Name\"),\nvalue!(\"non-existent name\"))).aggregates([star_count_aggregate!(\"count\"),\ncolumn_count_aggregate!(\"composer_count\" => \"Composer\", distinct: true),\n(\"average_price\",\ncolumn_aggregate(\"UnitPrice\",\n\"avg\").into()),]))]).order_by([asc!(\"_id\")])).relationships([(\"tracks\",\nrelationship(\"Track\", [(\"AlbumId\", &[\"AlbumId\"])]))])).await?"
+---
+- rows:
+    - tracks:
+        aggregates:
+          average_price: ~
+          composer_count: 0
+          count: 0
+    - tracks:
+        aggregates:
+          average_price: ~
+          composer_count: 0
+          count: 0
+    - tracks:
+        aggregates:
+          average_price: ~
+          composer_count: 0
+          count: 0

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__aggregates_over_related_collection.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__aggregates_over_related_collection.snap
@@ -1,0 +1,17 @@
+---
+source: crates/integration-tests/src/tests/local_relationship.rs
+expression: "run_connector_query(Connector::Chinook,\nquery_request().collection(\"Album\").query(query().predicate(is_in(target!(\"AlbumId\"),\n[json!(15), json!(91),\njson!(227)])).fields([relation_field!(\"tracks\" => \"tracks\",\nquery().aggregates([star_count_aggregate!(\"count\"),\n(\"average_price\",\ncolumn_aggregate(\"UnitPrice\",\n\"avg\").into()),]))]).order_by([asc!(\"_id\")])).relationships([(\"tracks\",\nrelationship(\"Track\", [(\"AlbumId\", &[\"AlbumId\"])]))])).await?"
+---
+- rows:
+    - tracks:
+        aggregates:
+          average_price: 0.99
+          count: 5
+    - tracks:
+        aggregates:
+          average_price: 0.99
+          count: 16
+    - tracks:
+        aggregates:
+          average_price: 1.99
+          count: 19

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__remote_relationship__aggregates_request_with_variable_sets.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__remote_relationship__aggregates_request_with_variable_sets.snap
@@ -1,0 +1,8 @@
+---
+source: crates/integration-tests/src/tests/remote_relationship.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().collection(\"movies\").variables([[(\"year\",\njson!(2014))]]).query(query().predicate(binop(\"_eq\", target!(\"year\"),\nvariable!(year))).aggregates([(\"average_viewer_rating\",\ncolumn_aggregate(\"tomatoes.viewer.rating\", \"avg\").into(),),\ncolumn_count_aggregate!(\"rated_count\" => \"rated\", distinct: true),\nstar_count_aggregate!(\"count\"),])),).await?"
+---
+- aggregates:
+    average_viewer_rating: 3.2435114503816793
+    rated_count: 10
+    count: 1147

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__remote_relationship__aggregates_request_with_variable_sets_over_empty_collection_subset.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__remote_relationship__aggregates_request_with_variable_sets_over_empty_collection_subset.snap
@@ -1,0 +1,8 @@
+---
+source: crates/integration-tests/src/tests/remote_relationship.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().collection(\"movies\").variables([[(\"year\",\njson!(2014))]]).query(query().predicate(and([binop(\"_eq\", target!(\"year\"),\nvariable!(year)),\nbinop(\"_eq\", target!(\"title\"),\nvalue!(\"non-existent title\")),])).aggregates([(\"average_viewer_rating\",\ncolumn_aggregate(\"tomatoes.viewer.rating\", \"avg\").into(),),\ncolumn_count_aggregate!(\"rated_count\" => \"rated\", distinct: true),\nstar_count_aggregate!(\"count\"),])),).await?"
+---
+- aggregates:
+    average_viewer_rating: ~
+    rated_count: 0
+    count: 0

--- a/crates/mongodb-agent-common/src/constants.rs
+++ b/crates/mongodb-agent-common/src/constants.rs
@@ -1,7 +1,5 @@
-use mongodb::bson::{self, Bson};
+use mongodb::bson;
 use serde::Deserialize;
-
-pub const RESULT_FIELD: &str = "result";
 
 /// Value must match the field name in [BsonRowSet]
 pub const ROW_SET_AGGREGATES_KEY: &str = "aggregates";
@@ -15,7 +13,7 @@ pub const ROW_SET_ROWS_KEY: &str = "rows";
 #[derive(Debug, Deserialize)]
 pub struct BsonRowSet {
     #[serde(default)]
-    pub aggregates: Bson, // name matches ROW_SET_AGGREGATES_KEY
+    pub aggregates: Option<bson::Document>, // name matches ROW_SET_AGGREGATES_KEY
     #[serde(default)]
     pub groups: Vec<bson::Document>, // name matches ROW_SET_GROUPS_KEY
     #[serde(default)]

--- a/crates/mongodb-agent-common/src/mongodb/sanitize.rs
+++ b/crates/mongodb-agent-common/src/mongodb/sanitize.rs
@@ -1,15 +1,5 @@
 use std::borrow::Cow;
 
-use mongodb::bson::{doc, Document};
-
-/// Produces a MongoDB expression that references a field by name in a way that is safe from code
-/// injection.
-///
-/// TODO: equivalent to ColumnRef::Expression
-pub fn get_field(name: &str) -> Document {
-    doc! { "$getField": { "$literal": name } }
-}
-
 /// Given a name returns a valid variable name for use in MongoDB aggregation expressions. Outputs
 /// are guaranteed to be distinct for distinct inputs. Consistently returns the same output for the
 /// same input string.

--- a/crates/mongodb-agent-common/src/query/aggregates.rs
+++ b/crates/mongodb-agent-common/src/query/aggregates.rs
@@ -1,153 +1,120 @@
 use std::collections::BTreeMap;
 
-use configuration::MongoScalarType;
-use mongodb::bson::{self, doc, Bson};
-use mongodb_support::{
-    aggregate::{Accumulator, Pipeline, Selection, Stage},
-    BsonScalarType,
-};
+use indexmap::IndexMap;
+use mongodb::bson::{bson, Bson};
+use mongodb_support::aggregate::{Accumulator, Pipeline, Selection, Stage};
 use ndc_models::FieldName;
 
-use crate::{
-    aggregation_function::AggregationFunction,
-    comparison_function::ComparisonFunction,
-    constants::RESULT_FIELD,
-    constants::{ROW_SET_AGGREGATES_KEY, ROW_SET_GROUPS_KEY, ROW_SET_ROWS_KEY},
-    interface_types::MongoAgentError,
-    mongo_query_plan::{
-        Aggregate, ComparisonTarget, ComparisonValue, Expression, Query, QueryPlan, Type,
-    },
-    mongodb::sanitize::get_field,
-};
+use crate::{aggregation_function::AggregationFunction, mongo_query_plan::Aggregate};
 
-use super::{
-    column_ref::ColumnRef, groups::pipeline_for_groups, make_selector,
-    pipeline::pipeline_for_fields_facet, query_level::QueryLevel,
-};
+use super::column_ref::ColumnRef;
 
-type Result<T> = std::result::Result<T, MongoAgentError>;
-
-/// Returns a map of pipelines for evaluating each aggregate independently, paired with
-/// a `Selection` that converts results of each pipeline to a format compatible with
-/// `QueryResponse`.
-pub fn facet_pipelines_for_query(
-    query_plan: &QueryPlan,
-    query_level: QueryLevel,
-) -> Result<(BTreeMap<String, Pipeline>, Selection)> {
-    let query = &query_plan.query;
-    let Query {
-        aggregates,
-        fields,
-        groups,
-        ..
-    } = query;
-    let mut facet_pipelines = aggregates
-        .iter()
-        .flatten()
-        .map(|(key, aggregate)| Ok((key.to_string(), pipeline_for_aggregate(aggregate.clone())?)))
-        .collect::<Result<BTreeMap<_, _>>>()?;
-
-    // This builds a map that feeds into a `$replaceWith` pipeline stage to build a map of
-    // aggregation results.
-    let aggregate_selections: bson::Document = aggregates
-        .iter()
-        .flatten()
-        .map(|(key, aggregate)| {
-            // The facet result for each aggregate is an array containing a single document which
-            // has a field called `result`. This code selects each facet result by name, and pulls
-            // out the `result` value.
-            let value_expr = doc! {
-                "$getField": {
-                    "field": RESULT_FIELD, // evaluates to the value of this field
-                    "input": { "$first": get_field(key.as_str()) }, // field is accessed from this document
-                },
-            };
-
-            // Matching SQL semantics, if a **count** aggregation does not match any rows we want
-            // to return zero. Other aggregations should return null.
-            let value_expr = if is_count(aggregate) {
-                doc! {
-                    "$ifNull": [value_expr, 0],
-                }
-            // Otherwise if the aggregate value is missing because the aggregation applied to an
-            // empty document set then provide an explicit `null` value.
-            } else {
-                convert_aggregate_result_type(value_expr, aggregate)
-            };
-
-            (key.to_string(), value_expr.into())
-        })
-        .collect();
-
-    let select_aggregates = if !aggregate_selections.is_empty() {
-        Some((
-            ROW_SET_AGGREGATES_KEY.to_string(),
-            aggregate_selections.into(),
-        ))
-    } else {
-        None
+pub fn pipeline_for_aggregates(aggregates: &IndexMap<FieldName, Aggregate>) -> Pipeline {
+    let group_stage = Stage::Group {
+        key_expression: Bson::Null,
+        accumulators: accumulators_for_aggregates(aggregates),
     };
-
-    let (groups_pipeline_facet, select_groups) = match groups {
-        Some(grouping) => {
-            let internal_key = "__GROUPS__";
-            let groups_pipeline = pipeline_for_groups(grouping)?;
-            let facet = (internal_key.to_string(), groups_pipeline);
-            let selection = (
-                ROW_SET_GROUPS_KEY.to_string(),
-                Bson::String(format!("${internal_key}")),
-            );
-            (Some(facet), Some(selection))
-        }
-        None => (None, None),
-    };
-
-    let (rows_pipeline_facet, select_rows) = match fields {
-        Some(_) => {
-            let internal_key = "__ROWS__";
-            let rows_pipeline = pipeline_for_fields_facet(query_plan, query_level)?;
-            let facet = (internal_key.to_string(), rows_pipeline);
-            let selection = (
-                ROW_SET_ROWS_KEY.to_string().to_string(),
-                Bson::String(format!("${internal_key}")),
-            );
-            (Some(facet), Some(selection))
-        }
-        None => (None, None),
-    };
-
-    for (key, pipeline) in [groups_pipeline_facet, rows_pipeline_facet]
-        .into_iter()
-        .flatten()
-    {
-        facet_pipelines.insert(key, pipeline);
-    }
-
-    let selection = Selection::new(
-        [select_aggregates, select_groups, select_rows]
-            .into_iter()
-            .flatten()
-            .collect(),
-    );
-
-    Ok((facet_pipelines, selection))
+    let replace_with_stage = Stage::ReplaceWith(selection_for_aggregates(aggregates));
+    Pipeline::new(vec![group_stage, replace_with_stage])
 }
 
-fn is_count(aggregate: &Aggregate) -> bool {
+pub fn accumulators_for_aggregates(
+    aggregates: &IndexMap<FieldName, Aggregate>,
+) -> BTreeMap<String, Accumulator> {
+    aggregates
+        .into_iter()
+        .map(|(name, aggregate)| (name.to_string(), aggregate_to_accumulator(aggregate)))
+        .collect()
+}
+
+fn aggregate_to_accumulator(aggregate: &Aggregate) -> Accumulator {
+    use Aggregate as A;
     match aggregate {
-        Aggregate::ColumnCount { .. } => true,
-        Aggregate::StarCount { .. } => true,
-        Aggregate::SingleColumn { .. } => false,
+        A::ColumnCount {
+            column,
+            field_path,
+            distinct,
+            ..
+        } => {
+            let field_ref = ColumnRef::from_column_and_field_path(column, field_path.as_ref())
+                .into_aggregate_expression()
+                .into_bson();
+            if *distinct {
+                Accumulator::AddToSet(field_ref)
+            } else {
+                Accumulator::Sum(bson!({
+                    "$cond": {
+                        "if": { "$eq": [field_ref, null] }, // count non-null, non-missing values
+                        "then": 0,
+                        "else": 1,
+                    }
+                }))
+            }
+        }
+        A::SingleColumn {
+            column,
+            field_path,
+            function,
+            ..
+        } => {
+            use AggregationFunction as A;
+
+            let field_ref = ColumnRef::from_column_and_field_path(column, field_path.as_ref())
+                .into_aggregate_expression()
+                .into_bson();
+
+            match function {
+                A::Avg => Accumulator::Avg(field_ref),
+                A::Min => Accumulator::Min(field_ref),
+                A::Max => Accumulator::Max(field_ref),
+                A::Sum => Accumulator::Sum(field_ref),
+            }
+        }
+        A::StarCount => Accumulator::Sum(bson!(1)),
     }
+}
+
+pub fn selection_for_aggregates(aggregates: &IndexMap<FieldName, Aggregate>) -> Selection {
+    let selected_aggregates = aggregates
+        .iter()
+        .map(|(key, aggregate)| selection_for_aggregate(key, aggregate))
+        .collect();
+    Selection::new(selected_aggregates)
+}
+
+pub fn selection_for_aggregate(key: &FieldName, aggregate: &Aggregate) -> (String, Bson) {
+    let column_ref = ColumnRef::from_field(key).into_aggregate_expression();
+    // Selecting distinct counts requires some post-processing since the $group stage produces
+    // an array of unique values. We need to count the non-null values in that array.
+    let value_expression = match aggregate {
+        Aggregate::ColumnCount { distinct, .. } if *distinct => bson!({
+            "$reduce": {
+                "input": column_ref,
+                "initialValue": 0,
+                "in": {
+                    "$cond": {
+                        "if": { "$eq": ["$$this", null] },
+                        "then": "$$value",
+                        "else": { "$sum": ["$$value", 1] },
+                    }
+                },
+            }
+        }),
+        aggregate if aggregate.is_count() => bson!({
+            "$ifNull": [column_ref, 0]
+        }),
+        _ => bson!({
+            "$ifNull": [column_ref, null]
+        }),
+    };
+    let selection = convert_aggregate_result_type(value_expression, aggregate);
+    (key.to_string(), selection)
 }
 
 /// The system expects specific return types for specific aggregates. That means we may need
 /// to do a numeric type conversion here. The conversion applies to the aggregated result,
 /// not to input values.
-pub fn convert_aggregate_result_type(
-    column_ref: impl Into<Bson>,
-    aggregate: &Aggregate,
-) -> bson::Document {
+fn convert_aggregate_result_type(column_ref: impl Into<Bson>, aggregate: &Aggregate) -> Bson {
     let convert_to = match aggregate {
         Aggregate::ColumnCount { .. } => None,
         Aggregate::SingleColumn {
@@ -159,113 +126,14 @@ pub fn convert_aggregate_result_type(
     };
     match convert_to {
         // $convert implicitly fills `null` if input value is missing
-        Some(scalar_type) => doc! {
+        Some(scalar_type) => bson!({
                 "$convert": {
                 "input": column_ref,
                 "to": scalar_type.bson_name(),
             }
-        },
-        None => doc! {
-            "$ifNull": [column_ref, null]
-        },
+        }),
+        None => column_ref.into(),
     }
-}
-
-// TODO: We can probably combine some aggregates in the same group stage:
-// - single column
-// - star count
-// - column count, non-distinct
-//
-// We might still need separate facets for
-// - column count, distinct
-//
-// The issue with non-distinct column count is we want to exclude null and non-existent values.
-// That could probably be done with an accumulator like,
-//
-//     count: if $exists: ["$column", true] then 1 else 0
-//
-// Distinct counts need a group by the target column AFAIK so they need a facet.
-fn pipeline_for_aggregate(aggregate: Aggregate) -> Result<Pipeline> {
-    let pipeline = match aggregate {
-        Aggregate::ColumnCount {
-            column,
-            field_path,
-            distinct,
-            ..
-        } if distinct => {
-            let target_field = mk_target_field(column, field_path);
-            Pipeline::new(vec![
-                filter_to_documents_with_value(target_field.clone())?,
-                Stage::Group {
-                    key_expression: ColumnRef::from_comparison_target(&target_field)
-                        .into_aggregate_expression()
-                        .into_bson(),
-                    accumulators: [].into(),
-                },
-                Stage::Count(RESULT_FIELD.to_string()),
-            ])
-        }
-
-        // TODO: ENG-1465 count by distinct
-        Aggregate::ColumnCount {
-            column,
-            field_path,
-            distinct: _,
-            ..
-        } => Pipeline::new(vec![
-            filter_to_documents_with_value(mk_target_field(column, field_path))?,
-            Stage::Count(RESULT_FIELD.to_string()),
-        ]),
-
-        Aggregate::SingleColumn {
-            column,
-            field_path,
-            function,
-            ..
-        } => {
-            use AggregationFunction as A;
-
-            let field_ref = ColumnRef::from_column_and_field_path(&column, field_path.as_ref())
-                .into_aggregate_expression()
-                .into_bson();
-
-            let accumulator = match function {
-                A::Avg => Accumulator::Avg(field_ref),
-                A::Min => Accumulator::Min(field_ref),
-                A::Max => Accumulator::Max(field_ref),
-                A::Sum => Accumulator::Sum(field_ref),
-            };
-            Pipeline::new(vec![Stage::Group {
-                key_expression: Bson::Null,
-                accumulators: [(RESULT_FIELD.to_string(), accumulator)].into(),
-            }])
-        }
-
-        Aggregate::StarCount {} => Pipeline::new(vec![Stage::Count(RESULT_FIELD.to_string())]),
-    };
-    Ok(pipeline)
-}
-
-fn mk_target_field(name: FieldName, field_path: Option<Vec<FieldName>>) -> ComparisonTarget {
-    ComparisonTarget::Column {
-        name,
-        arguments: Default::default(),
-        field_path,
-        field_type: Type::Scalar(MongoScalarType::ExtendedJSON), // type does not matter here
-    }
-}
-
-fn filter_to_documents_with_value(target_field: ComparisonTarget) -> Result<Stage> {
-    Ok(Stage::Match(make_selector(
-        &Expression::BinaryComparisonOperator {
-            column: target_field,
-            operator: ComparisonFunction::NotEqual,
-            value: ComparisonValue::Scalar {
-                value: serde_json::Value::Null,
-                value_type: Type::Scalar(MongoScalarType::Bson(BsonScalarType::Null)),
-            },
-        },
-    )?))
 }
 
 #[cfg(test)]

--- a/crates/mongodb-agent-common/src/query/column_ref.rs
+++ b/crates/mongodb-agent-common/src/query/column_ref.rs
@@ -86,8 +86,8 @@ impl<'a> ColumnRef<'a> {
         .expect("field_path is not empty") // safety: NonEmpty cannot be empty
     }
 
-    pub fn from_field(field_name: &ndc_models::FieldName) -> ColumnRef<'_> {
-        fold_path_element(None, field_name.as_ref())
+    pub fn from_field(field_name: &str) -> ColumnRef<'_> {
+        fold_path_element(None, field_name)
     }
 
     pub fn from_relationship(relationship_name: &ndc_models::RelationshipName) -> ColumnRef<'_> {
@@ -103,8 +103,8 @@ impl<'a> ColumnRef<'a> {
         Self::ExpressionStringShorthand(format!("$${variable_name}").into())
     }
 
-    pub fn into_nested_field<'b: 'a>(self, field_name: &'b ndc_models::FieldName) -> ColumnRef<'b> {
-        fold_path_element(Some(self), field_name.as_ref())
+    pub fn into_nested_field<'b: 'a>(self, field_name: &'b str) -> ColumnRef<'b> {
+        fold_path_element(Some(self), field_name)
     }
 
     pub fn into_aggregate_expression(self) -> AggregationExpression {

--- a/crates/mongodb-agent-common/src/query/foreach.rs
+++ b/crates/mongodb-agent-common/src/query/foreach.rs
@@ -72,6 +72,9 @@ pub fn pipeline_for_foreach(
                 })
                 .collect()
         }
+        ResponseFacets::AggregatesOnly(_) => {
+            doc! { ROW_SET_AGGREGATES_KEY: "$query" }
+        }
         ResponseFacets::FieldsOnly(_) => {
             doc! { ROW_SET_ROWS_KEY: "$query" }
         }

--- a/crates/mongodb-agent-common/src/query/foreach.rs
+++ b/crates/mongodb-agent-common/src/query/foreach.rs
@@ -73,7 +73,7 @@ pub fn pipeline_for_foreach(
                 .collect()
         }
         ResponseFacets::AggregatesOnly(_) => {
-            doc! { ROW_SET_AGGREGATES_KEY: "$query" }
+            doc! { ROW_SET_AGGREGATES_KEY: { "$first": "$query" } }
         }
         ResponseFacets::FieldsOnly(_) => {
             doc! { ROW_SET_ROWS_KEY: "$query" }
@@ -265,7 +265,7 @@ mod tests {
                                 "title": { "$ifNull": ["$title", null] }
                             }}],
                         } },
-                        { 
+                        {
                             "$replaceWith": {
                                 "aggregates": { "$first": "$__AGGREGATES__" },
                                 "rows": "$__ROWS__",

--- a/crates/mongodb-agent-common/src/query/foreach.rs
+++ b/crates/mongodb-agent-common/src/query/foreach.rs
@@ -371,7 +371,7 @@ mod tests {
             },
             {
                 "$replaceWith": {
-                    "aggregates": "$query",
+                    "aggregates": { "$first": "$query" },
                 }
             },
         ]);

--- a/crates/mongodb-agent-common/src/query/groups.rs
+++ b/crates/mongodb-agent-common/src/query/groups.rs
@@ -37,7 +37,7 @@ pub fn pipeline_for_groups(grouping: &Grouping) -> Result<Pipeline> {
     // TODO: ENG-1563 to implement 'query.aggregates.group_by.paginate' apply grouping.limit and
     // grouping.offset **after** group stage because those options count groups, not documents
 
-    let replace_with_stage = Stage::ReplaceWith(selection_for_grouping_internal(grouping, "_id"));
+    let replace_with_stage = Stage::ReplaceWith(selection_for_grouping(grouping, "_id"));
 
     Ok(Pipeline::new(
         [
@@ -75,14 +75,7 @@ fn dimensions_to_expression(dimensions: &[Dimension]) -> bson::Array {
         .collect()
 }
 
-pub fn selection_for_grouping(grouping: &Grouping) -> Selection {
-    // This function is called externally to propagate groups from relationship lookups. In that
-    // case the group has already gone through [selection_for_grouping_internal] once so we want to
-    // reference the dimensions key as "dimensions".
-    selection_for_grouping_internal(grouping, GROUP_DIMENSIONS_KEY)
-}
-
-fn selection_for_grouping_internal(grouping: &Grouping, dimensions_field_name: &str) -> Selection {
+fn selection_for_grouping(grouping: &Grouping, dimensions_field_name: &str) -> Selection {
     let dimensions = (
         GROUP_DIMENSIONS_KEY.to_string(),
         bson!(format!("${dimensions_field_name}")),

--- a/crates/mongodb-agent-common/src/query/groups.rs
+++ b/crates/mongodb-agent-common/src/query/groups.rs
@@ -1,18 +1,19 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::borrow::Cow;
 
-use indexmap::IndexMap;
 use mongodb::bson::{self, bson};
-use mongodb_support::aggregate::{Accumulator, Pipeline, Selection, SortDocument, Stage};
-use ndc_models::{FieldName, OrderDirection};
+use mongodb_support::aggregate::{Pipeline, Selection, SortDocument, Stage};
+use ndc_models::OrderDirection;
 
 use crate::{
-    aggregation_function::AggregationFunction,
     constants::GROUP_DIMENSIONS_KEY,
     interface_types::MongoAgentError,
-    mongo_query_plan::{Aggregate, Dimension, GroupOrderBy, GroupOrderByTarget, Grouping},
+    mongo_query_plan::{Dimension, GroupOrderBy, GroupOrderByTarget, Grouping},
 };
 
-use super::{aggregates::convert_aggregate_result_type, column_ref::ColumnRef};
+use super::{
+    aggregates::{accumulators_for_aggregates, selection_for_aggregate},
+    column_ref::ColumnRef,
+};
 
 type Result<T> = std::result::Result<T, MongoAgentError>;
 
@@ -74,62 +75,6 @@ fn dimensions_to_expression(dimensions: &[Dimension]) -> bson::Array {
         .collect()
 }
 
-fn accumulators_for_aggregates(
-    aggregates: &IndexMap<FieldName, Aggregate>,
-) -> BTreeMap<String, Accumulator> {
-    aggregates
-        .into_iter()
-        .map(|(name, aggregate)| (name.to_string(), aggregate_to_accumulator(aggregate)))
-        .collect()
-}
-
-fn aggregate_to_accumulator(aggregate: &Aggregate) -> Accumulator {
-    use Aggregate as A;
-    match aggregate {
-        A::ColumnCount {
-            column,
-            field_path,
-            distinct,
-            ..
-        } => {
-            let field_ref = ColumnRef::from_column_and_field_path(column, field_path.as_ref())
-                .into_aggregate_expression()
-                .into_bson();
-            if *distinct {
-                Accumulator::AddToSet(field_ref)
-            } else {
-                Accumulator::Sum(bson!({
-                    "$cond": {
-                        "if": { "$eq": [field_ref, null] }, // count non-null, non-missing values
-                        "then": 0,
-                        "else": 1,
-                    }
-                }))
-            }
-        }
-        A::SingleColumn {
-            column,
-            field_path,
-            function,
-            ..
-        } => {
-            use AggregationFunction as A;
-
-            let field_ref = ColumnRef::from_column_and_field_path(column, field_path.as_ref())
-                .into_aggregate_expression()
-                .into_bson();
-
-            match function {
-                A::Avg => Accumulator::Avg(field_ref),
-                A::Min => Accumulator::Min(field_ref),
-                A::Max => Accumulator::Max(field_ref),
-                A::Sum => Accumulator::Sum(field_ref),
-            }
-        }
-        A::StarCount => Accumulator::Sum(bson!(1)),
-    }
-}
-
 pub fn selection_for_grouping(grouping: &Grouping) -> Selection {
     // This function is called externally to propagate groups from relationship lookups. In that
     // case the group has already gone through [selection_for_grouping_internal] once so we want to
@@ -142,29 +87,10 @@ fn selection_for_grouping_internal(grouping: &Grouping, dimensions_field_name: &
         GROUP_DIMENSIONS_KEY.to_string(),
         bson!(format!("${dimensions_field_name}")),
     );
-    let selected_aggregates = grouping.aggregates.iter().map(|(key, aggregate)| {
-        let column_ref = ColumnRef::from_field(key).into_aggregate_expression();
-        // Selecting distinct counts requires some post-processing since the $group stage produces
-        // an array of unique values. We need to count the non-null values in that array.
-        let value_expression = match aggregate {
-            Aggregate::ColumnCount { distinct, .. } if *distinct => bson!({
-                "$reduce": {
-                    "input": column_ref,
-                    "initialValue": 0,
-                    "in": {
-                        "$cond": {
-                            "if": { "$eq": ["$$this", null] },
-                            "then": "$$value",
-                            "else": { "$sum": ["$$value", 1] },
-                        }
-                    },
-                }
-            }),
-            _ => column_ref.into_bson(),
-        };
-        let selection = convert_aggregate_result_type(value_expression, aggregate);
-        (key.to_string(), selection.into())
-    });
+    let selected_aggregates = grouping
+        .aggregates
+        .iter()
+        .map(|(key, aggregate)| selection_for_aggregate(key, aggregate));
     let selection_doc = std::iter::once(dimensions)
         .chain(selected_aggregates)
         .collect();

--- a/crates/mongodb-agent-common/src/query/pipeline.rs
+++ b/crates/mongodb-agent-common/src/query/pipeline.rs
@@ -1,26 +1,32 @@
+use std::collections::BTreeMap;
+
 use itertools::Itertools;
-use mongodb_support::aggregate::{Pipeline, Stage};
+use mongodb::bson::{bson, Bson};
+use mongodb_support::aggregate::{Pipeline, Selection, Stage};
 use tracing::instrument;
 
 use crate::{
+    constants::{ROW_SET_AGGREGATES_KEY, ROW_SET_GROUPS_KEY, ROW_SET_ROWS_KEY},
     interface_types::MongoAgentError,
     mongo_query_plan::{MongoConfiguration, Query, QueryPlan},
     mongodb::sanitize::get_field,
 };
 
 use super::{
-    aggregates::facet_pipelines_for_query, foreach::pipeline_for_foreach,
-    groups::pipeline_for_groups, is_response_faceted::is_response_faceted, make_selector,
+    aggregates::pipeline_for_aggregates, foreach::pipeline_for_foreach,
+    groups::pipeline_for_groups, is_response_faceted::ResponseFacets, make_selector,
     make_sort::make_sort_stages, native_query::pipeline_for_native_query, query_level::QueryLevel,
     relations::pipeline_for_relations, selection::selection_for_fields,
 };
+
+type Result<T> = std::result::Result<T, MongoAgentError>;
 
 /// Shared logic to produce a MongoDB aggregation pipeline for a query request.
 #[instrument(name = "Build Query Pipeline" skip_all, fields(internal.visibility = "user"))]
 pub fn pipeline_for_query_request(
     config: &MongoConfiguration,
     query_plan: &QueryPlan,
-) -> Result<Pipeline, MongoAgentError> {
+) -> Result<Pipeline> {
     if let Some(variable_sets) = &query_plan.variables {
         pipeline_for_foreach(variable_sets, config, query_plan)
     } else {
@@ -35,7 +41,7 @@ pub fn pipeline_for_non_foreach(
     config: &MongoConfiguration,
     query_plan: &QueryPlan,
     query_level: QueryLevel,
-) -> Result<Pipeline, MongoAgentError> {
+) -> Result<Pipeline> {
     let query = &query_plan.query;
     let Query {
         limit,
@@ -61,7 +67,7 @@ pub fn pipeline_for_non_foreach(
         .iter()
         .map(make_sort_stages)
         .flatten_ok()
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>>>()?;
     let limit_stage = limit.map(Into::into).map(Stage::Limit);
     let skip_stage = offset.map(Into::into).map(Stage::Skip);
 
@@ -72,20 +78,100 @@ pub fn pipeline_for_non_foreach(
         .chain(limit_stage)
         .for_each(|stage| pipeline.push(stage));
 
-    let diverging_stages = if is_response_faceted(query) {
-        let (facet_pipelines, select_facet_results) =
-            facet_pipelines_for_query(query_plan, query_level)?;
-        let aggregation_stages = Stage::Facet(facet_pipelines);
-        let replace_with_stage = Stage::ReplaceWith(select_facet_results);
-        Pipeline::from_iter([aggregation_stages, replace_with_stage])
-    } else if let Some(grouping) = &query.groups {
-        pipeline_for_groups(grouping)?
-    } else {
-        pipeline_for_fields_facet(query_plan, query_level)?
+    let diverging_stages = match ResponseFacets::from_query(query) {
+        ResponseFacets::Combination { .. } => {
+            let (facet_pipelines, select_facet_results) =
+                facet_pipelines_for_query(query_plan, query_level)?;
+            let facet_stage = Stage::Facet(facet_pipelines);
+            let replace_with_stage = Stage::ReplaceWith(select_facet_results);
+            Pipeline::new(vec![facet_stage, replace_with_stage])
+        }
+        ResponseFacets::AggregatesOnly(aggregates) => pipeline_for_aggregates(aggregates),
+        ResponseFacets::FieldsOnly(_) => pipeline_for_fields_facet(query_plan, query_level)?,
+        ResponseFacets::GroupsOnly(grouping) => pipeline_for_groups(grouping)?,
     };
 
     pipeline.append(diverging_stages);
     Ok(pipeline)
+}
+
+/// Returns a map of pipelines for evaluating each aggregate independently, paired with
+/// a `Selection` that converts results of each pipeline to a format compatible with
+/// `QueryResponse`.
+fn facet_pipelines_for_query(
+    query_plan: &QueryPlan,
+    query_level: QueryLevel,
+) -> Result<(BTreeMap<String, Pipeline>, Selection)> {
+    let query = &query_plan.query;
+    let Query {
+        aggregates,
+        fields,
+        groups,
+        ..
+    } = query;
+    let mut facet_pipelines = BTreeMap::new();
+
+    let (aggregates_pipeline_facet, select_aggregates) = match aggregates {
+        Some(aggregates) => {
+            let internal_key = "__AGGREGATES__";
+            let aggregates_pipeline = pipeline_for_aggregates(aggregates);
+            let facet = (internal_key.to_string(), aggregates_pipeline);
+            let selection = (
+                ROW_SET_AGGREGATES_KEY.to_string(),
+                bson!({ "$first": format!("${internal_key}") }),
+            );
+            (Some(facet), Some(selection))
+        }
+        None => (None, None),
+    };
+
+    let (groups_pipeline_facet, select_groups) = match groups {
+        Some(grouping) => {
+            let internal_key = "__GROUPS__";
+            let groups_pipeline = pipeline_for_groups(grouping)?;
+            let facet = (internal_key.to_string(), groups_pipeline);
+            let selection = (
+                ROW_SET_GROUPS_KEY.to_string(),
+                Bson::String(format!("${internal_key}")),
+            );
+            (Some(facet), Some(selection))
+        }
+        None => (None, None),
+    };
+
+    let (rows_pipeline_facet, select_rows) = match fields {
+        Some(_) => {
+            let internal_key = "__ROWS__";
+            let rows_pipeline = pipeline_for_fields_facet(query_plan, query_level)?;
+            let facet = (internal_key.to_string(), rows_pipeline);
+            let selection = (
+                ROW_SET_ROWS_KEY.to_string().to_string(),
+                Bson::String(format!("${internal_key}")),
+            );
+            (Some(facet), Some(selection))
+        }
+        None => (None, None),
+    };
+
+    for (key, pipeline) in [
+        aggregates_pipeline_facet,
+        groups_pipeline_facet,
+        rows_pipeline_facet,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        facet_pipelines.insert(key, pipeline);
+    }
+
+    let selection = Selection::new(
+        [select_aggregates, select_groups, select_rows]
+            .into_iter()
+            .flatten()
+            .collect(),
+    );
+
+    Ok((facet_pipelines, selection))
 }
 
 /// Generate a pipeline to select fields requested by the given query. This is intended to be used
@@ -95,7 +181,7 @@ pub fn pipeline_for_non_foreach(
 pub fn pipeline_for_fields_facet(
     query_plan: &QueryPlan,
     query_level: QueryLevel,
-) -> Result<Pipeline, MongoAgentError> {
+) -> Result<Pipeline> {
     let Query { relationships, .. } = &query_plan.query;
 
     let mut selection = selection_for_fields(query_plan.query.fields.as_ref())?;

--- a/crates/mongodb-agent-common/src/query/pipeline.rs
+++ b/crates/mongodb-agent-common/src/query/pipeline.rs
@@ -9,11 +9,10 @@ use crate::{
     constants::{ROW_SET_AGGREGATES_KEY, ROW_SET_GROUPS_KEY, ROW_SET_ROWS_KEY},
     interface_types::MongoAgentError,
     mongo_query_plan::{MongoConfiguration, Query, QueryPlan},
-    mongodb::sanitize::get_field,
 };
 
 use super::{
-    aggregates::pipeline_for_aggregates, foreach::pipeline_for_foreach,
+    aggregates::pipeline_for_aggregates, column_ref::ColumnRef, foreach::pipeline_for_foreach,
     groups::pipeline_for_groups, is_response_faceted::ResponseFacets, make_selector,
     make_sort::make_sort_stages, native_query::pipeline_for_native_query, query_level::QueryLevel,
     relations::pipeline_for_relations, selection::selection_for_fields,
@@ -192,7 +191,7 @@ pub fn pipeline_for_fields_facet(
             selection = selection.try_map_document(|mut doc| {
                 doc.insert(
                     relationship_key.to_owned(),
-                    get_field(relationship_key.as_str()),
+                    ColumnRef::from_field(relationship_key.as_str()).into_aggregate_expression(),
                 );
                 doc
             })?;

--- a/crates/mongodb-agent-common/src/query/relations.rs
+++ b/crates/mongodb-agent-common/src/query/relations.rs
@@ -257,7 +257,7 @@ mod tests {
                     "students": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "class_students" } },
+                                "input": "$class_students",
                                 "in": {
                                     "student_name": "$$this.student_name"
                                 }
@@ -346,7 +346,7 @@ mod tests {
                     "class": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "student_class" } },
+                                "input": "$student_class",
                                 "in": {
                                     "class_title": "$$this.class_title"
                                 }
@@ -443,7 +443,7 @@ mod tests {
                     "students": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "students" } },
+                                "input": "$students",
                                 "in": {
                                     "student_name": "$$this.student_name"
                                 }
@@ -520,7 +520,7 @@ mod tests {
                     "join": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "join" } },
+                                "input": "$join",
                                 "in": {
                                     "invalid_name": "$$this.invalid_name",
                                 }
@@ -622,7 +622,7 @@ mod tests {
                         },
                         {
                             "$replaceWith": {
-                                "assignments": { "$getField": { "$literal": "assignments" } },
+                                "assignments": "$assignments",
                                 "student_name": { "$ifNull": ["$name", null] },
                             },
                         },
@@ -636,7 +636,7 @@ mod tests {
                     "students": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "students" } },
+                                "input": "$students",
                                 "in": {
                                     "assignments": "$$this.assignments",
                                     "student_name": "$$this.student_name",
@@ -720,27 +720,14 @@ mod tests {
                     },
                     "pipeline": [
                         {
-                            "$facet": {
-                                "aggregate_count": [
-                                    { "$count": "result" },
-                                ],
+                            "$group": {
+                                "_id": null,
+                                "aggregate_count": { "$sum": 1 },
                             }
                         },
                         {
                             "$replaceWith": {
-                                "aggregates": {
-                                    "aggregate_count": {
-                                        "$ifNull": [
-                                            {
-                                                "$getField": {
-                                                    "field": "result",
-                                                    "input": { "$first": { "$getField": { "$literal": "aggregate_count" } } },
-                                                },
-                                            },
-                                            0,
-                                        ]
-                                    },
-                                },
+                                "aggregate_count": { "$ifNull": ["$aggregate_count", 0] },
                             },
                         }
                     ],
@@ -750,16 +737,16 @@ mod tests {
             {
                 "$replaceWith": {
                     "students_aggregate": {
-                        "$let": {
-                            "vars": {
-                                "row_set": { "$first": { "$getField": { "$literal": "students" } } }
-                            },
-                            "in": {
-                                "aggregates": {
-                                    "aggregate_count": "$$row_set.aggregates.aggregate_count"
+                        "aggregates": {
+                            "$let": {
+                                "vars": {
+                                    "aggregates": { "$first": "$students" }
+                                },
+                                "in": {
+                                    "aggregate_count": { "$ifNull": ["$$aggregates.aggregate_count", 0] }
                                 }
                             }
-                        }
+                        },
                     }
                 },
             },
@@ -864,7 +851,7 @@ mod tests {
               "movie": {
                 "rows": {
                   "$map": {
-                    "input": { "$getField": { "$literal": "movie" } },
+                    "input": "$movie",
                     "in": {
                         "year": "$$this.year",
                         "title": "$$this.title",
@@ -986,7 +973,7 @@ mod tests {
                     "movie": {
                         "rows": {
                             "$map": {
-                                "input": { "$getField": { "$literal": "movie" } },
+                                "input": "$movie",
                                 "in": {
                                     "credits": "$$this.credits",
                                 }

--- a/crates/mongodb-agent-common/src/query/relations.rs
+++ b/crates/mongodb-agent-common/src/query/relations.rs
@@ -76,7 +76,8 @@ fn make_lookup_stage(
     let source_selector = single_mapping.map(|(field_name, _)| field_name);
     let target_selector = single_mapping.map(|(_, target_path)| target_path);
 
-    let source_key = source_selector.and_then(|f| ColumnRef::from_field(f).into_match_key());
+    let source_key =
+        source_selector.and_then(|f| ColumnRef::from_field(f.as_ref()).into_match_key());
     let target_key =
         target_selector.and_then(|path| ColumnRef::from_field_path(path.as_ref()).into_match_key());
 
@@ -137,7 +138,7 @@ fn lookup_with_uncorrelated_subquery(
         .map(|local_field| {
             (
                 variable(local_field.as_str()),
-                ColumnRef::from_field(local_field)
+                ColumnRef::from_field(local_field.as_ref())
                     .into_aggregate_expression()
                     .into_bson(),
             )

--- a/crates/mongodb-agent-common/src/query/selection.rs
+++ b/crates/mongodb-agent-common/src/query/selection.rs
@@ -5,16 +5,15 @@ use ndc_models::FieldName;
 use nonempty::NonEmpty;
 
 use crate::{
-    constants::{ROW_SET_AGGREGATES_KEY, ROW_SET_GROUPS_KEY, ROW_SET_ROWS_KEY},
-    interface_types::MongoAgentError,
-    mongo_query_plan::{Field, NestedArray, NestedField, NestedObject},
-    mongodb::sanitize::get_field,
-    query::{
-        aggregates::selection_for_aggregates, column_ref::ColumnRef, groups::selection_for_grouping,
+    constants::{
+        GROUP_DIMENSIONS_KEY, ROW_SET_AGGREGATES_KEY, ROW_SET_GROUPS_KEY, ROW_SET_ROWS_KEY,
     },
+    interface_types::MongoAgentError,
+    mongo_query_plan::{Aggregate, Field, Grouping, NestedArray, NestedField, NestedObject},
+    query::column_ref::ColumnRef,
 };
 
-use super::is_response_faceted::ResponseFacets;
+use super::{aggregates::replace_missing_aggregate_value, is_response_faceted::ResponseFacets};
 
 /// Creates a document to use in a $replaceWith stage to limit query results to the specific fields
 /// requested. Assumes that only fields are requested.
@@ -98,24 +97,58 @@ fn selection_for_field(
             // appropriate aliases. At this point all we need to do is to prune the selection down
             // to requested fields, omitting fields of the relationship that were selected for
             // filtering and sorting.
-            let field_selection = |fields: &IndexMap<FieldName, Field>| -> Document {
+            fn field_selection(fields: &IndexMap<FieldName, Field>) -> Document {
                 fields
                     .iter()
                     .map(|(field_name, _)| {
                         (
                             field_name.to_string(),
                             ColumnRef::variable("this")
-                                .into_nested_field(field_name)
+                                .into_nested_field(field_name.as_ref())
                                 .into_aggregate_expression()
                                 .into_bson(),
                         )
                     })
                     .collect()
-            };
+            }
+
+            fn aggregates_selection(
+                from: ColumnRef<'_>,
+                aggregates: &IndexMap<FieldName, Aggregate>,
+                check_for_null: bool,
+            ) -> Document {
+                aggregates
+                    .into_iter()
+                    .map(|(aggregate_name, aggregate)| {
+                        let value_ref = from
+                            .clone()
+                            .into_nested_field(aggregate_name.as_ref())
+                            .into_aggregate_expression()
+                            .into_bson();
+                        let value_ref = if check_for_null {
+                            replace_missing_aggregate_value(value_ref, aggregate.is_count())
+                        } else {
+                            value_ref
+                        };
+                        (aggregate_name.to_string(), value_ref)
+                    })
+                    .collect()
+            }
+
+            fn group_selection(from: ColumnRef<'_>, grouping: &Grouping) -> Document {
+                let mut selection = aggregates_selection(from, &grouping.aggregates, false);
+                selection.insert(
+                    GROUP_DIMENSIONS_KEY,
+                    ColumnRef::variable("this")
+                        .into_nested_field(GROUP_DIMENSIONS_KEY)
+                        .into_aggregate_expression(),
+                );
+                selection
+            }
 
             // Field of the incoming pipeline document that contains data fetched for the
             // relationship.
-            let relationship_field = get_field(relationship.as_str());
+            let relationship_field = ColumnRef::from_field(relationship.as_ref());
 
             let doc = match ResponseFacets::from_parameters(
                 aggregates.as_ref(),
@@ -130,8 +163,15 @@ fn selection_for_field(
                     let mut new_row_set = Document::new();
 
                     if let Some(aggregates) = aggregates {
-                        new_row_set
-                            .insert(ROW_SET_AGGREGATES_KEY, selection_for_aggregates(aggregates));
+                        new_row_set.insert(
+                            ROW_SET_AGGREGATES_KEY,
+                            aggregates_selection(
+                                ColumnRef::variable("row_set")
+                                    .into_nested_field(ROW_SET_AGGREGATES_KEY),
+                                aggregates,
+                                false,
+                            ),
+                        );
                     }
 
                     if let Some(fields) = fields {
@@ -139,7 +179,7 @@ fn selection_for_field(
                             ROW_SET_ROWS_KEY,
                             doc! {
                                 "$map": {
-                                    "input": format!("${ROW_SET_ROWS_KEY}"),
+                                    "input": ColumnRef::variable("row_set").into_nested_field(ROW_SET_ROWS_KEY).into_aggregate_expression(),
                                     "in": field_selection(fields),
                                 }
                             },
@@ -151,9 +191,8 @@ fn selection_for_field(
                             ROW_SET_GROUPS_KEY,
                             doc! {
                                 "$map": {
-                                    "input": format!("${ROW_SET_GROUPS_KEY}"),
-                                    "as": "CURRENT", // implicitly changes the document root in `in` to be the array element
-                                    "in": selection_for_grouping(grouping),
+                                    "input": ColumnRef::variable("row_set").into_nested_field(ROW_SET_GROUPS_KEY).into_aggregate_expression(),
+                                    "in": group_selection(ColumnRef::variable("this"), grouping),
                                 }
                             },
                         );
@@ -161,7 +200,7 @@ fn selection_for_field(
 
                     doc! {
                         "$let": {
-                            "vars": { "CURRENT": { "$first": relationship_field } },
+                            "vars": { "row_set": { "$first": relationship_field.into_aggregate_expression() } },
                             "in": new_row_set,
                         }
                     }
@@ -169,29 +208,24 @@ fn selection_for_field(
                 ResponseFacets::AggregatesOnly(aggregates) => doc! {
                     ROW_SET_AGGREGATES_KEY: {
                         "$let": {
-                            "vars": { "CURRENT": { "$first": relationship_field } },
-                            "in": selection_for_aggregates(aggregates),
+                            "vars": { "aggregates": { "$first": relationship_field.into_aggregate_expression() } },
+                            "in": aggregates_selection(ColumnRef::variable("aggregates"), aggregates, true),
                         }
                     }
                 },
                 ResponseFacets::FieldsOnly(fields) => doc! {
                     ROW_SET_ROWS_KEY: {
                         "$map": {
-                            "input": relationship_field,
+                            "input": relationship_field.into_aggregate_expression(),
                             "in": field_selection(fields),
                         }
                     }
                 },
                 ResponseFacets::GroupsOnly(grouping) => doc! {
-                    // We can reuse the grouping selection logic instead of writing a custom one
-                    // like with `field_selection` because `selection_for_grouping` only selects
-                    // top-level keys - it doesn't have logic that we don't want to duplicate like
-                    // `selection_for_field` does.
                     ROW_SET_GROUPS_KEY: {
                         "$map": {
-                            "input": relationship_field,
-                            "as": "CURRENT", // implicitly changes the document root in `in` to be the array element
-                            "in": selection_for_grouping(grouping),
+                            "input": relationship_field.into_aggregate_expression(),
+                            "in": group_selection(ColumnRef::variable("this"), grouping),
                         }
                     }
                 },
@@ -227,7 +261,7 @@ fn nested_column_reference<'a>(
     column: &'a FieldName,
 ) -> ColumnRef<'a> {
     match parent {
-        Some(parent) => parent.into_nested_field(column),
+        Some(parent) => parent.into_nested_field(column.as_ref()),
         None => ColumnRef::from_field_path(NonEmpty::singleton(column)),
     }
 }

--- a/crates/mongodb-agent-common/src/query/selection.rs
+++ b/crates/mongodb-agent-common/src/query/selection.rs
@@ -406,7 +406,7 @@ mod tests {
                 "class_students": {
                     "rows": {
                         "$map": {
-                            "input": { "$getField": { "$literal": "class_students" } },
+                            "input": "$class_students",
                             "in": {
                                 "name": "$$this.name"
                             },
@@ -416,7 +416,7 @@ mod tests {
                 "students": {
                     "rows": {
                         "$map": {
-                            "input": { "$getField": { "$literal": "class_students_0" } },
+                            "input": "$class_students_0",
                             "in": {
                                 "student_name": "$$this.student_name"
                             },

--- a/crates/ndc-query-plan/src/query_plan/aggregation.rs
+++ b/crates/ndc-query-plan/src/query_plan/aggregation.rs
@@ -46,6 +46,14 @@ impl<T: ConnectorTypes> Aggregate<T> {
             Aggregate::StarCount => Cow::Owned(T::count_aggregate_type()),
         }
     }
+
+    pub fn is_count(&self) -> bool {
+        match self {
+            Aggregate::ColumnCount { .. } => true,
+            Aggregate::SingleColumn { .. } => false,
+            Aggregate::StarCount => true,
+        }
+    }
 }
 
 #[derive(Derivative)]


### PR DESCRIPTION
The logic for count aggregations for grouped data in #145 was an improvement over what was already in place for ungrouped data. Instead of leaving two separate code paths with different logic I unified logic for both to use the new logic from #145.

This allowed removing unnecessary uses of the `$facet` stage which forks the aggregation pipeline. Previously every aggregate used a separate facet. Now we only need facets for incompatibly-grouped data - one query that combines ungrouped aggregates with groups, or that combines either of those with field selection. This required additional changes to response processing to remove facet unpacking logic. The new system does mean that there are a couple of places where we have to explicitly fill in null or zero results for aggregate queries with no matching rows.

While I was going over aggregate logic I noticed some unescaped field references when referencing aggregate result names. I fixed these to use `ColumnRef` which escapes names. While I was at it I removed the last couple of uses of the old `getField` helper, and replaced them with the new-and-improved `ColumnRef`.