### PR TITLE
do not use $lookup for query with variables if only single variable set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      - 'v*'
+      - 'jessehallett/eng-1621-mongodb-vector-search-native-query-does-not-work-in-remote'
     tags:
       - 'v*'
 

--- a/crates/integration-tests/src/tests/native_query.rs
+++ b/crates/integration-tests/src/tests/native_query.rs
@@ -62,3 +62,65 @@ async fn runs_native_query_with_variable_sets() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn runs_native_query_with_a_single_variable_set() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request()
+                .variables([[("count", 3)]])
+                .collection("title_word_frequency")
+                .query(
+                    query()
+                        .predicate(binop("_eq", target!("count"), variable!(count)))
+                        .order_by([asc!("_id")])
+                        .limit(20)
+                        .fields([field!("_id"), field!("count")]),
+                )
+        )
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_native_query_without_input_collection_with_variable_sets() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request()
+                .variables([[("type", "decimal")], [("type", "date")]])
+                .collection("extended_json_test_data")
+                .query(
+                    query()
+                        .predicate(binop("_eq", target!("type"), variable!(type)))
+                        .order_by([asc!("type"), asc!("value")])
+                        .fields([field!("type"), field!("value")]),
+                )
+        )
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn runs_native_query_without_input_collection_with_single_variable_set() -> anyhow::Result<()>
+{
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request()
+                .variables([[("type", "decimal")]])
+                .collection("extended_json_test_data")
+                .query(
+                    query()
+                        .predicate(binop("_eq", target!("type"), variable!(type)))
+                        .order_by([asc!("type"), asc!("value")])
+                        .fields([field!("type"), field!("value")]),
+                )
+        )
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_with_a_single_variable_set.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_with_a_single_variable_set.snap
@@ -1,0 +1,45 @@
+---
+source: crates/integration-tests/src/tests/native_query.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().variables([[(\"count\",\n3)]]).collection(\"title_word_frequency\").query(query().predicate(binop(\"_eq\",\ntarget!(\"count\"),\nvariable!(count))).order_by([asc!(\"_id\")]).limit(20).fields([field!(\"_id\"),\nfield!(\"count\")]),)).await?"
+---
+- rows:
+    - _id: "#1"
+      count: 3
+    - _id: "'n"
+      count: 3
+    - _id: "'n'"
+      count: 3
+    - _id: (Not)
+      count: 3
+    - _id: "100"
+      count: 3
+    - _id: 10th
+      count: 3
+    - _id: "15"
+      count: 3
+    - _id: "174"
+      count: 3
+    - _id: "23"
+      count: 3
+    - _id: 3-D
+      count: 3
+    - _id: "42"
+      count: 3
+    - _id: "420"
+      count: 3
+    - _id: "72"
+      count: 3
+    - _id: Abandoned
+      count: 3
+    - _id: Abendland
+      count: 3
+    - _id: Absence
+      count: 3
+    - _id: Absent
+      count: 3
+    - _id: Abu
+      count: 3
+    - _id: Accident
+      count: 3
+    - _id: Accidental
+      count: 3

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_without_input_collection_with_single_variable_set.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_without_input_collection_with_single_variable_set.snap
@@ -1,0 +1,11 @@
+---
+source: crates/integration-tests/src/tests/native_query.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().variables([[(\"type\",\n\"decimal\")]]).collection(\"extended_json_test_data\").query(query().predicate(binop(\"_eq\",\ntarget!(\"type\"),\nvariable!(type))).order_by([asc!(\"type\"),\nasc!(\"value\")]).fields([field!(\"type\"), field!(\"value\")]),)).await?"
+---
+- rows:
+    - type: decimal
+      value:
+        $numberDecimal: "1"
+    - type: decimal
+      value:
+        $numberDecimal: "2"

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_without_input_collection_with_variable_sets.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__native_query__runs_native_query_without_input_collection_with_variable_sets.snap
@@ -1,0 +1,20 @@
+---
+source: crates/integration-tests/src/tests/native_query.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().variables([[(\"type\", \"decimal\")],\n[(\"type\",\n\"date\")]]).collection(\"extended_json_test_data\").query(query().predicate(binop(\"_eq\",\ntarget!(\"type\"),\nvariable!(type))).order_by([asc!(\"type\"),\nasc!(\"value\")]).fields([field!(\"type\"), field!(\"value\")]),)).await?"
+---
+- rows:
+    - type: decimal
+      value:
+        $numberDecimal: "1"
+    - type: decimal
+      value:
+        $numberDecimal: "2"
+- rows:
+    - type: date
+      value:
+        $date:
+          $numberLong: "1637571600000"
+    - type: date
+      value:
+        $date:
+          $numberLong: "1724164680000"

--- a/crates/mongodb-agent-common/src/query/execute_query_request.rs
+++ b/crates/mongodb-agent-common/src/query/execute_query_request.rs
@@ -1,17 +1,16 @@
 use futures::Stream;
 use futures_util::TryStreamExt as _;
-use mongodb::bson;
-use mongodb_support::aggregate::Pipeline;
+use mongodb::{bson, options::AggregateOptions};
+use mongodb_support::aggregate::AggregateCommand;
 use ndc_models::{QueryRequest, QueryResponse};
 use ndc_query_plan::plan_for_query_request;
 use tracing::{instrument, Instrument};
 
-use super::{pipeline::pipeline_for_query_request, response::serialize_query_response};
+use super::{pipeline::command_for_query_request, response::serialize_query_response};
 use crate::{
     interface_types::MongoAgentError,
     mongo_query_plan::{MongoConfiguration, QueryPlan},
     mongodb::{CollectionTrait as _, DatabaseTrait},
-    query::QueryTarget,
 };
 
 type Result<T> = std::result::Result<T, MongoAgentError>;
@@ -31,8 +30,8 @@ pub async fn execute_query_request(
     );
     let query_plan = preprocess_query_request(config, query_request)?;
     tracing::debug!(?query_plan, "abstract query plan");
-    let pipeline = pipeline_for_query_request(config, &query_plan)?;
-    let documents = execute_query_pipeline(database, config, &query_plan, pipeline).await?;
+    let command = command_for_query_request(config, &query_plan)?;
+    let documents = execute_query_command(database, command).await?;
     let response = serialize_query_response(config.extended_json_mode(), &query_plan, documents)?;
     Ok(response)
 }
@@ -47,18 +46,23 @@ fn preprocess_query_request(
 }
 
 #[instrument(name = "Execute Query Pipeline", skip_all, fields(internal.visibility = "user"))]
-async fn execute_query_pipeline(
+async fn execute_query_command(
     database: impl DatabaseTrait,
-    config: &MongoConfiguration,
-    query_plan: &QueryPlan,
-    pipeline: Pipeline,
+    AggregateCommand {
+        collection,
+        pipeline,
+        let_vars,
+    }: AggregateCommand,
 ) -> Result<Vec<bson::Document>> {
-    let target = QueryTarget::for_request(config, query_plan);
     tracing::debug!(
-        ?target,
+        ?collection,
         pipeline = %serde_json::to_string(&pipeline).unwrap(),
+        let_vars = %serde_json::to_string(&let_vars).unwrap(),
         "executing query"
     );
+
+    let aggregate_options =
+        let_vars.map(|let_vars| AggregateOptions::builder().let_vars(let_vars).build());
 
     // The target of a query request might be a collection, or it might be a native query. In the
     // latter case there is no collection to perform the aggregation against. So instead of sending
@@ -67,12 +71,12 @@ async fn execute_query_pipeline(
     // If the query request includes variable sets then instead of specifying the target collection
     // up front that is deferred until the `$lookup` stage of the aggregation pipeline. That is
     // another case where we call `db.aggregate` instead of `db.<collection>.aggregate`.
-    let documents = match (target.input_collection(), query_plan.has_variables()) {
-        (Some(collection_name), false) => {
+    let documents = match collection {
+        Some(collection_name) => {
             let collection = database.collection(collection_name.as_str());
             collect_response_documents(
                 collection
-                    .aggregate(pipeline, None)
+                    .aggregate(pipeline, aggregate_options)
                     .instrument(tracing::info_span!(
                         "MongoDB Aggregate Command",
                         internal.visibility = "user"
@@ -81,10 +85,10 @@ async fn execute_query_pipeline(
             )
             .await
         }
-        _ => {
+        None => {
             collect_response_documents(
                 database
-                    .aggregate(pipeline, None)
+                    .aggregate(pipeline, aggregate_options)
                     .instrument(tracing::info_span!(
                         "MongoDB Aggregate Command",
                         internal.visibility = "user"

--- a/crates/mongodb-agent-common/src/query/make_selector/mod.rs
+++ b/crates/mongodb-agent-common/src/query/make_selector/mod.rs
@@ -33,7 +33,7 @@ pub fn make_selector(expr: &Expression) -> Result<Document> {
 mod tests {
     use configuration::MongoScalarType;
     use mongodb::bson::{self, bson, doc};
-    use mongodb_support::BsonScalarType;
+    use mongodb_support::{aggregate::AggregateCommand, BsonScalarType};
     use ndc_models::UnaryComparisonOperator;
     use ndc_query_plan::{plan_for_query_request, Scope};
     use ndc_test_helpers::{
@@ -47,7 +47,7 @@ mod tests {
         mongo_query_plan::{
             ComparisonTarget, ComparisonValue, ExistsInCollection, Expression, Type,
         },
-        query::pipeline_for_query_request,
+        query::command_for_query_request,
         test_helpers::{chinook_config, chinook_relationships},
     };
 
@@ -193,7 +193,7 @@ mod tests {
 
         let config = chinook_config();
         let plan = plan_for_query_request(&config, request)?;
-        let pipeline = pipeline_for_query_request(&config, &plan)?;
+        let AggregateCommand { pipeline, let_vars } = command_for_query_request(&config, &plan)?;
 
         let expected_pipeline = bson!([
             {
@@ -256,6 +256,7 @@ mod tests {
         ]);
 
         assert_eq!(bson::to_bson(&pipeline).unwrap(), expected_pipeline);
+        assert_eq!(let_vars, None);
         Ok(())
     }
 

--- a/crates/mongodb-agent-common/src/query/mod.rs
+++ b/crates/mongodb-agent-common/src/query/mod.rs
@@ -19,7 +19,7 @@ use self::execute_query_request::execute_query_request;
 pub use self::{
     make_selector::make_selector,
     make_sort::make_sort_stages,
-    pipeline::{is_response_faceted, pipeline_for_non_foreach, pipeline_for_query_request},
+    pipeline::{command_for_query_request, is_response_faceted, pipeline_for_non_foreach},
     query_target::QueryTarget,
     response::QueryResponseError,
 };

--- a/crates/mongodb-agent-common/src/query/response.rs
+++ b/crates/mongodb-agent-common/src/query/response.rs
@@ -56,7 +56,11 @@ pub fn serialize_query_response(
 ) -> Result<QueryResponse> {
     let collection_name = &query_plan.collection;
 
-    let row_sets = if query_plan.has_variables() {
+    let row_sets = if query_plan
+        .variables
+        .as_ref()
+        .is_some_and(|variables| variables.len() != 1)
+    {
         response_documents
             .into_iter()
             .map(|document| {

--- a/crates/mongodb-support/src/aggregate/command.rs
+++ b/crates/mongodb-support/src/aggregate/command.rs
@@ -1,0 +1,12 @@
+use mongodb::bson::Document;
+
+use super::Pipeline;
+
+/// Aggregate command used with, e.g., `db.<collection-name>.aggregate()`
+///
+/// This is not a complete implementation - only the fields needed by the connector are listed.
+pub struct AggregateCommand {
+    pub collection: Option<String>,
+    pub pipeline: Pipeline,
+    pub let_vars: Option<Document>,
+}

--- a/crates/mongodb-support/src/aggregate/mod.rs
+++ b/crates/mongodb-support/src/aggregate/mod.rs
@@ -1,10 +1,12 @@
 mod accumulator;
+mod command;
 mod pipeline;
 mod selection;
 mod sort_document;
 mod stage;
 
 pub use self::accumulator::Accumulator;
+pub use self::command::AggregateCommand;
 pub use self::pipeline::Pipeline;
 pub use self::selection::Selection;
 pub use self::sort_document::SortDocument;


### PR DESCRIPTION
This allows a `$vectorSearch` to be the target of a remote join if the join forwards exactly one variable set.