### PR TITLE
ci: fix deploy workflow by updating upload-artifact action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       run: nix build --print-build-logs
 
     - name: Create release 🚀
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mongodb-connector
         path: result/bin/mongodb-connector


### PR DESCRIPTION
The deploy automation is currently failing to upload a binary because actions/upload-artifact@v3 is past its EOL.