### PR TITLE
skip system and unsample-able collections in introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ This changelog documents the changes between release versions.
 
 ### Fixed
 
+- Database introspection no longer fails if any individual collection cannot be sampled ([#160](https://github.com/hasura/ndc-mongodb/pull/160))
+
 ## [1.7.1] - 2025-03-12
 
 ### Added
 
-- Add watch command while initializing metadata (#157)
+- Add watch command while initializing metadata ([#157](https://github.com/hasura/ndc-mongodb/pull/157))
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "enum-iterator",
  "futures-util",
  "googletest 0.13.0",
+ "indent",
  "indexmap 2.2.6",
  "itertools",
  "json-structural-diff",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1.0.80"
 clap = { version = "4.5.1", features = ["derive", "env"] }
 enum-iterator = "^2.0.0"
 futures-util = "0.3.28"
+indent = "^0.1.1"
 indexmap = { workspace = true }
 itertools = { workspace = true }
 json-structural-diff = "^0.2.0"


### PR DESCRIPTION
We have had users unable to run introspection because sampling fails on an automatically-generated collection called `system.views`. This collection is generated if the database has any views. On some deployments attempts to run aggregate (which is what introspection sampling uses) fail with a permissions error. We've seen this come up in MongoDB v6 running on Atlas.

Collections prefixed with `system.` are reserved for internal use. We shouldn't include them in introspection. https://www.mongodb.com/docs/manual/reference/system-collections/#synopsis

This PR makes two changes:
- skip collections whose names begin with `system.`, and log a warning
- when sampling a collection fails for any reason skip that collection and log a warning instead of failing the entire introspection process