### PR TITLE
Add version and ndcSpecGeneration to connector packaging

### DIFF
--- a/connector-definition/connector-metadata.yaml
+++ b/connector-definition/connector-metadata.yaml
@@ -1,3 +1,5 @@
+version: v2
+ndcSpecGeneration: v0.2
 packagingDefinition:
   type: PrebuiltDockerImage
   dockerImage:


### PR DESCRIPTION
This is required by the CLI for NDC spec 0.2.0 onwards.