### PR TITLE
when filtering related collection need to include nested fields in comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog documents the changes between release versions.
 
 ## [Unreleased]
 
+### Fixed
+
+- Filtering on field of related collection inside nested object that is not selected for output ([#171](https://github.com/hasura/ndc-mongodb/pull/171))
+
 ## [1.8.2] - 2025-06-13
 
 ### Added

--- a/crates/integration-tests/src/tests/local_relationship.rs
+++ b/crates/integration-tests/src/tests/local_relationship.rs
@@ -90,6 +90,28 @@ async fn filters_by_non_null_field_of_related_collection() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+async fn filters_by_nested_field_of_related_collection() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        graphql_query(
+            r#"
+            query {
+              comments(where: {movie: {imdb: {rating: {_eq: 9.2}}}}, limit: 10, order_by: {id: Asc}) {
+                text
+                movie {
+                  title
+                  year
+                }
+              }
+            }
+            "#
+        )
+        .run()
+        .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn filters_by_field_of_relationship_of_relationship() -> anyhow::Result<()> {
     assert_yaml_snapshot!(
         graphql_query(

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__filters_by_nested_field_of_related_collection.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__local_relationship__filters_by_nested_field_of_related_collection.snap
@@ -1,0 +1,47 @@
+---
+source: crates/integration-tests/src/tests/local_relationship.rs
+expression: "graphql_query(r#\"\n            query {\n              comments(where: {movie: {imdb: {rating: {_eq: 9.2}}}}, limit: 10, order_by: {id: Asc}) {\n                text\n                movie {\n                  title\n                  year\n                }\n              }\n            }\n            \"#).run().await?"
+---
+data:
+  comments:
+    - text: Odit libero reprehenderit vitae dolore. Consequuntur neque ab eos id quibusdam. Odit laborum ex rem.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Minima cupiditate veritatis rerum sequi vitae illum. Ea eos voluptas non adipisci quidem suscipit cum quo. In itaque cum architecto non blanditiis.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Enim id inventore magnam hic. Error a nobis earum delectus saepe qui. Tenetur odit facilis ratione voluptates. Aliquid ullam temporibus porro mollitia.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Eveniet aliquid et quae consectetur saepe repellendus veritatis voluptates. Harum porro facilis modi in. Dolor architecto vel reiciendis fuga.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Aliquid iste eos facere corporis repellendus doloremque. Beatae libero itaque dolorum delectus debitis. Pariatur optio tempora pariatur unde culpa dolores.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Doloribus esse quos atque voluptatem nihil libero molestias porro. Accusantium sapiente perferendis quae fugiat dicta. Ab consequuntur dicta blanditiis enim vitae odit tempora.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Unde ratione ad nemo eligendi cupiditate aut iusto natus. Consequuntur cum totam laborum rerum dolorum sint. Odit recusandae autem dolorum natus sunt.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Veniam doloribus ea cum error. Voluptates voluptatum tempore culpa earum nihil. Voluptate ad asperiores architecto hic.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Eveniet voluptate quo quas quia fuga eos quibusdam. Neque molestiae quis assumenda nostrum. Ipsa laudantium esse voluptas recusandae.
+      movie:
+        title: The Godfather
+        year: 1972
+    - text: Mollitia ut sint veniam accusamus quam. Quod ullam voluptatum perspiciatis odio. Non ullam maxime recusandae ipsam possimus sit. Ullam doloribus quisquam at.
+      movie:
+        title: The Godfather
+        year: 1972
+errors: ~

--- a/crates/ndc-query-plan/src/plan_for_query_request/helpers.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/helpers.rs
@@ -165,10 +165,7 @@ pub fn field_selection_for_comparison_target<T: ConnectorTypes>(
         column_type: column_type.clone(),
         fields: comparison_target
             .field_path()
-            .map(|field_path| {
-                let (field_name, rest_path) = split_field_path_at_head(field_path)?;
-                nested_field_by_field_type(field_name, rest_path, column_type)
-            })
+            .map(|field_path| nested_field_by_parent_type(column_type, field_path))
             .transpose()?,
     };
     Ok(field)
@@ -178,7 +175,9 @@ pub fn field_path_to_nested_field<T: ConnectorTypes>(
     parent_object_type: &plan::ObjectType<T::ScalarType>,
     field_path: &[ndc::FieldName],
 ) -> Result<plan::NestedField<T>> {
-    let (field_name, rest_path) = split_field_path_at_head(field_path)?;
+    let [field_name, rest_path @ ..] = field_path else {
+        return Err(QueryPlanError::TypeMismatch("empty field path".to_string()));
+    };
     Ok(plan::NestedField::Object(plan::NestedObject {
         fields: [(
             field_name.clone(),
@@ -188,52 +187,31 @@ pub fn field_path_to_nested_field<T: ConnectorTypes>(
     }))
 }
 
-fn nested_field_by_field_type<T: ConnectorTypes>(
-    field_name: &ndc::FieldName,
-    rest_path: &[ndc::FieldName],
-    field_type: &plan::Type<T::ScalarType>,
+fn nested_field_by_parent_type<T: ConnectorTypes>(
+    parent_type: &plan::Type<T::ScalarType>,
+    field_path: &[ndc::FieldName],
 ) -> Result<plan::NestedField<T>> {
-    match field_type {
-        plan::Type::Object(object_type) => Ok(plan::NestedField::Object(plan::NestedObject {
-            fields: [(
-                field_name.clone(),
-                field_path_to_field_selection(object_type, field_name, rest_path)?,
-            )]
-            .into(),
-        })),
+    match parent_type {
+        plan::Type::Object(object_type) => field_path_to_nested_field(object_type, field_path),
         plan::Type::ArrayOf(t) => Ok(plan::NestedField::Array(plan::NestedArray {
-            fields: Box::new(nested_array_field(rest_path, t)?),
+            fields: Box::new(nested_field_by_parent_type(t, field_path)?),
         })),
-        plan::Type::Nullable(t) => nested_field_by_field_type(field_name, rest_path, t),
+        plan::Type::Nullable(t) => nested_field_by_parent_type(t, field_path),
         plan::Type::Scalar(_) => Err(QueryPlanError::ExpectedObject {
-            path: vec![field_name.to_string()],
+            path: vec![field_path
+                .first()
+                .map(|f| f.to_string())
+                .unwrap_or_else(|| "unknown".to_string())],
         }),
     }
 }
 
-fn nested_array_field<T: ConnectorTypes>(
-    field_path: &[ndc::FieldName],
-    array_element_type: &plan::Type<T::ScalarType>,
-) -> Result<plan::NestedField<T>> {
-    match array_element_type {
-        plan::Type::Object(object_type) => Ok(field_path_to_nested_field(object_type, field_path)?),
-        plan::Type::ArrayOf(t) => {
-            let (_, rest_path) = split_field_path_at_head(field_path)?;
-            Ok(plan::NestedField::Array(plan::NestedArray {
-                fields: Box::new(nested_array_field(rest_path, t)?),
-            }))
-        }
-        plan::Type::Nullable(t) => nested_array_field(field_path, t),
-        plan::Type::Scalar(_) => Err(QueryPlanError::ExpectedObject { path: vec![] }),
-    }
-}
-
 fn field_path_to_field_selection<T: ConnectorTypes>(
-    object_type: &plan::ObjectType<T::ScalarType>,
+    parent_object_type: &plan::ObjectType<T::ScalarType>,
     field_name: &ndc::FieldName,
     rest_path: &[ndc::FieldName],
 ) -> Result<plan::Field<T>> {
-    let field_type = find_object_field(object_type, field_name)?;
+    let field_type = find_object_field(parent_object_type, field_name)?;
     field_by_field_type(field_name.clone(), rest_path, field_type)
 }
 
@@ -262,20 +240,11 @@ fn field_by_field_type<T: ConnectorTypes>(
             fields: if rest_path.is_empty() {
                 None
             } else {
-                Some(nested_array_field(rest_path, element_type)?)
+                Some(nested_field_by_parent_type(element_type, rest_path)?)
             },
             column_type: field_type.clone(),
         },
         plan::Type::Nullable(t) => field_by_field_type(field_name, rest_path, t)?,
     };
     Ok(field)
-}
-
-fn split_field_path_at_head(
-    field_path: &[ndc::FieldName],
-) -> Result<(&ndc::FieldName, &[ndc::FieldName])> {
-    let [field_name, rest_path @ ..] = field_path else {
-        return Err(QueryPlanError::TypeMismatch("empty field path".to_string()));
-    };
-    Ok((field_name, rest_path))
 }

--- a/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
@@ -701,7 +701,25 @@ fn plan_for_exists<T: QueryContext>(
                 })
                 .transpose()?;
 
+            let fields = predicate
+                .as_ref()
+                .map(|p| {
+                    p.query_local_comparison_targets()
+                        .map(|comparison_target| {
+                            Ok((
+                                comparison_target.column_name().to_owned(),
+                                field_selection_for_comparison_target(
+                                    &collection_object_type,
+                                    comparison_target,
+                                )?,
+                            )) as Result<_>
+                        })
+                        .collect()
+                })
+                .transpose()?;
+
             let join_query = plan::Query {
+                fields,
                 predicate: predicate.clone(),
                 relationships: nested_state.into_relationships(),
                 ..Default::default()

--- a/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/mod.rs
@@ -15,7 +15,10 @@ mod tests;
 use std::{collections::VecDeque, iter::once};
 
 use crate::{self as plan, type_annotated_field, ObjectType, QueryPlan, Scope};
-use helpers::{find_nested_collection_type, value_type_in_possible_array_equality_comparison};
+use helpers::{
+    field_selection_for_comparison_target, find_nested_collection_type,
+    value_type_in_possible_array_equality_comparison,
+};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use ndc::{ExistsInCollection, QueryRequest};
@@ -575,7 +578,8 @@ fn plan_for_comparison_target<T: QueryContext>(
         }
         ndc::ComparisonTarget::RootCollectionColumn { name, field_path } => {
             let field_type =
-                find_object_field_path(root_collection_object_type, &name, field_path.as_ref())?.clone();
+                find_object_field_path(root_collection_object_type, &name, field_path.as_ref())?
+                    .clone();
             Ok(plan::ComparisonTarget::ColumnInScope {
                 name,
                 field_path,
@@ -646,20 +650,22 @@ fn plan_for_exists<T: QueryContext>(
                 })
                 .transpose()?;
 
-            let fields = predicate.as_ref().map(|p| {
-                p.query_local_comparison_targets()
-                    .map(|comparison_target| {
-                        (
-                            comparison_target.column_name().to_owned(),
-                            plan::Field::Column {
-                                column: comparison_target.column_name().clone(),
-                                column_type: comparison_target.get_field_type().clone(),
-                                fields: None,
-                            },
-                        )
-                    })
-                    .collect()
-            });
+            let fields = predicate
+                .as_ref()
+                .map(|p| {
+                    p.query_local_comparison_targets()
+                        .map(|comparison_target| {
+                            Ok((
+                                comparison_target.column_name().to_owned(),
+                                field_selection_for_comparison_target(
+                                    &collection_object_type,
+                                    comparison_target,
+                                )?,
+                            )) as Result<_>
+                        })
+                        .collect()
+                })
+                .transpose()?;
 
             let relationship_query = plan::Query {
                 fields,

--- a/crates/ndc-query-plan/src/plan_for_query_request/plan_test_helpers/field.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/plan_test_helpers/field.rs
@@ -2,7 +2,7 @@
 macro_rules! field {
     ($name:literal: $typ:expr) => {
         (
-            $name,
+            ::ndc_models::FieldName::from($name),
             $crate::Field::Column {
                 column: $name.into(),
                 column_type: $typ,
@@ -12,7 +12,7 @@ macro_rules! field {
     };
     ($name:literal => $column_name:literal: $typ:expr) => {
         (
-            $name,
+            ::ndc_models::FieldName::from($name),
             $crate::Field::Column {
                 column: $column_name.into(),
                 column_type: $typ,
@@ -22,7 +22,7 @@ macro_rules! field {
     };
     ($name:literal => $column_name:literal: $typ:expr, $fields:expr) => {
         (
-            $name,
+            ::ndc_models::FieldName::from($name),
             $crate::Field::Column {
                 column: $column_name.into(),
                 column_type: $typ,

--- a/crates/ndc-query-plan/src/plan_for_query_request/plan_test_helpers/mod.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/plan_test_helpers/mod.rs
@@ -276,6 +276,7 @@ pub fn make_flat_schema() -> TestContext {
             (
                 "Article".into(),
                 ndc_test_helpers::object_type([
+                    ("id", named_type(ScalarType::Int)),
                     ("author_id", named_type(ScalarType::Int)),
                     ("title", named_type(ScalarType::String)),
                     ("year", nullable(named_type(ScalarType::Int))),

--- a/crates/ndc-query-plan/src/plan_for_query_request/tests.rs
+++ b/crates/ndc-query-plan/src/plan_for_query_request/tests.rs
@@ -5,8 +5,9 @@ use serde_json::json;
 
 use crate::{
     self as plan,
+    field as plan_field,
     plan_for_query_request::plan_test_helpers::{
-        self, make_flat_schema, make_nested_schema, TestContext,
+        self, int, make_flat_schema, make_nested_schema, string, TestContext
     },
     query_plan::UnrelatedJoin,
     ExistsInCollection, Expression, Field, OrderBy, Query, QueryContext, QueryPlan, Relationship,
@@ -489,6 +490,11 @@ fn translates_root_column_references() -> Result<(), anyhow::Error> {
                             },
                         ],
                     }),
+                    fields: Some([
+                        plan_field!("author_id": int()),
+                        plan_field!("id": int()),
+                        plan_field!("title": string()),
+                    ].into()),
                     ..Default::default()
                 },
             },

--- a/crates/ndc-query-plan/src/query_plan.rs
+++ b/crates/ndc-query-plan/src/query_plan.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, fmt::Debug, iter};
 use derivative::Derivative;
 use indexmap::IndexMap;
 use itertools::Either;
-use ndc_models::{self as ndc, FieldName, OrderDirection, RelationshipType, UnaryComparisonOperator};
+use ndc_models::{
+    self as ndc, FieldName, OrderDirection, RelationshipType, UnaryComparisonOperator,
+};
 
 use crate::{vec_set::VecSet, Type};
 
@@ -392,6 +394,13 @@ impl<T: ConnectorTypes> ComparisonTarget<T> {
         match self {
             ComparisonTarget::Column { name, .. } => name,
             ComparisonTarget::ColumnInScope { name, .. } => name,
+        }
+    }
+
+    pub fn field_path(&self) -> Option<&Vec<ndc::FieldName>> {
+        match self {
+            ComparisonTarget::Column { field_path, .. } => field_path.as_ref(),
+            ComparisonTarget::ColumnInScope { field_path, .. } => field_path.as_ref(),
         }
     }
 


### PR DESCRIPTION
This comes up when filtering on a nested field in a related collection. For example, where there is a relation from `comments` to `movie`:

```graphql
query {
  comments(where: {movie: {imdb: {rating: {_eq: 9.2}}}}) {
    text
    movie {
      title
      year
    }
  }
}
```

In this example no records are returned because `imdb.rating` is not in scope when during filtering where that `where` predicate is applied.

We already have logic in place to include columns in joins if they are needed for an expression. But that logic did not account for **nested** fields. This PR updates the query planner to recursively include nested fields as needed if they are used in expressions.