### PR TITLE
escape names with invalid characters in mongodb query field selection

### DIFF
--- a/crates/integration-tests/src/tests/mod.rs
+++ b/crates/integration-tests/src/tests/mod.rs
@@ -16,4 +16,5 @@ mod native_mutation;
 mod native_query;
 mod permissions;
 mod remote_relationship;
+mod selection;
 mod sorting;

--- a/crates/integration-tests/src/tests/selection.rs
+++ b/crates/integration-tests/src/tests/selection.rs
@@ -1,0 +1,20 @@
+use crate::{connector::Connector, run_connector_query};
+use insta::assert_yaml_snapshot;
+use ndc_test_helpers::{asc, field, query, query_request};
+
+#[tokio::test]
+async fn selects_fields_with_weird_aliases() -> anyhow::Result<()> {
+    assert_yaml_snapshot!(
+        run_connector_query(
+            Connector::SampleMflix,
+            query_request().collection("movies").query(
+                query()
+                    .fields([field!("foo.bar" => "title"), field!("year")])
+                    .limit(10)
+                    .order_by([asc!("id")]),
+            )
+        )
+        .await?
+    );
+    Ok(())
+}

--- a/crates/integration-tests/src/tests/snapshots/integration_tests__tests__selection__selects_fields_with_weird_aliases.snap
+++ b/crates/integration-tests/src/tests/snapshots/integration_tests__tests__selection__selects_fields_with_weird_aliases.snap
@@ -1,0 +1,25 @@
+---
+source: crates/integration-tests/src/tests/selection.rs
+expression: "run_connector_query(Connector::SampleMflix,\nquery_request().collection(\"movies\").query(query().fields([field!(\"foo.bar\" =>\n\"title\"), field!(\"year\")]).limit(10).order_by([asc!(\"id\")]),)).await?"
+---
+- rows:
+    - foo.bar: Wild and Woolly
+      year: 1917
+    - foo.bar: In the Land of the Head Hunters
+      year: 1914
+    - foo.bar: Where Are My Children?
+      year: 1916
+    - foo.bar: The Poor Little Rich Girl
+      year: 1917
+    - foo.bar: The Birth of a Nation
+      year: 1915
+    - foo.bar: "Intolerance: Love's Struggle Throughout the Ages"
+      year: 1916
+    - foo.bar: Traffic in Souls
+      year: 1913
+    - foo.bar: A Corner in Wheat
+      year: 1909
+    - foo.bar: Blacksmith Scene
+      year: 1893
+    - foo.bar: The Immigrant
+      year: 1917


### PR DESCRIPTION
We had a bug when selecting fields with names containing dollar signs or dots, or when selecting fields using aliases containing those characters. What happened is the mongodb query plan would produce a stage like this:

```json
{
  "$replaceWith": {
    "foo.bar": "$title"
  }
}
```

The use of `"foo.bar"` leads to this error:

> MongoServerError: FieldPath field names may not contain '.'. Consider using $getField or $setField.

The fix is, as the error suggests, to use the `$setField` operator which takes a `field` argument that is not evaluated as an expression, and is therefore allowed to contain arbitrary characters.

```json
{
  "$replaceWith": {
    "$setField": {
      "field": "foo.bar",
      "value": "$title",
      "input": "$$CURRENT"
    }
  }
}
```

But that leads to an issue when we want to select multiple fields: in the first snippet the argument to `$replaceWith` was an object literal where we could set multiple fields. OTOH `{ "$setField": { ... } }` is an expression that produces an object with a single field, and does not accept more keys. To select multiple fields with escaping we have to nest calls to `$setField` for every selected field. For example,

```json
{
  "$replaceWith": {
    "$setField": {
      "field": "foo.bar",
      "value": "$title",
      "input": {
        "$setField": {
          "field": "year",
          "value": "$year",
          "input": {
            "$setField": {
              "field": "rated",
              "value": "$rated",
              "input": "$$CURRENT"
            }
          }
        }
      }
    }
  }
}
```

So that is what this PR does.