### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,19 +15,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Install Nix ❄
-      uses: DeterminateSystems/nix-installer-action@v4
+      uses: DeterminateSystems/nix-installer-action@65d7c888b2778e8cf30a07a88422ccb23499bfb8 # v4
 
     - name: Link Cachix 🔌
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
       with:
         name: '${{ vars.CACHIX_CACHE_NAME }}'
         authToken: '${{ secrets.CACHIX_CACHE_AUTH_TOKEN }}'
 
     - name: Login to GitHub Container Registry 📦
-      uses: docker/login-action@v1
+      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -47,19 +47,19 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Install Nix ❄
-      uses: DeterminateSystems/nix-installer-action@v4
+      uses: DeterminateSystems/nix-installer-action@65d7c888b2778e8cf30a07a88422ccb23499bfb8 # v4
 
     - name: Link Cachix 🔌
-      uses: cachix/cachix-action@v12
+      uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
       with:
         name: '${{ vars.CACHIX_CACHE_NAME }}'
         authToken: '${{ secrets.CACHIX_CACHE_AUTH_TOKEN }}'
 
     - name: Login to GitHub Container Registry 📦
-      uses: docker/login-action@v1
+      uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -72,7 +72,7 @@ jobs:
         cp result/bin/mongodb-connector release/mongodb-connector-${{ matrix.target }}
 
     - name: Upload binaries to workflow artifacts 🚀
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: mongodb-connector-${{ matrix.target }}
         path: release
@@ -110,10 +110,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: "25.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +129,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.linux-packages }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           shared-key: "build" # share the cache across jobs
 
@@ -164,7 +164,7 @@ jobs:
           mkdir -p release
           mv -v target/${{ matrix.target }}/release/mongodb-cli-plugin release/mongodb-cli-plugin-${{ matrix.target }}${{ matrix.extension }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mongodb-cli-plugin-${{ matrix.target }}${{ matrix.extension }}
           path: release
@@ -179,9 +179,9 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: release/artifacts
           merge-multiple: true
@@ -209,7 +209,7 @@ jobs:
           export VERSION="$GITHUB_REF_NAME"
           ./scripts/generate-manifest.sh
       
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: manifest.yaml
           path: release/manifest.yaml
@@ -221,14 +221,14 @@ jobs:
           echo "tagged_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         shell: bash
 
-      - uses: mindsers/changelog-reader-action@v2
+      - uses: mindsers/changelog-reader-action@97a0b06549019bb99a571f1664272db18031acff # v2
         id: changelog-reader
         with:
           version: ${{ steps.get-version.outputs.tagged_version }}
           path: ./CHANGELOG.md
 
       - name: create a draft release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           draft: true
           tag: v${{ steps.get-version.outputs.tagged_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v4
+        uses: DeterminateSystems/nix-installer-action@65d7c888b2778e8cf30a07a88422ccb23499bfb8 # v4
 
       - name: Link Cachix 🔌
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
         with:
           name: '${{ vars.CACHIX_CACHE_NAME }}'
           authToken: '${{ secrets.CACHIX_CACHE_AUTH_TOKEN }}'
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Nix ❄
-        uses: DeterminateSystems/nix-installer-action@v4
+        uses: DeterminateSystems/nix-installer-action@65d7c888b2778e8cf30a07a88422ccb23499bfb8 # v4
 
       - name: Link Cachix 🔌
-        uses: cachix/cachix-action@v12
+        uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f # v12
         with:
           name: '${{ vars.CACHIX_CACHE_NAME }}'
           authToken: '${{ secrets.CACHIX_CACHE_AUTH_TOKEN }}'


### PR DESCRIPTION
## Summary
- Pin all public GitHub Action references to their immutable commit SHAs
- Original version tags preserved as inline comments for maintainability
- Prevents supply chain attacks via mutable tag references

## Test plan
- [ ] Verify CI workflows still trigger and run correctly
- [ ] Spot-check a few pinned SHAs match their expected tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)