### PR TITLE
Add env-loader image variant for external secrets support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,95 @@ jobs:
         path: release
         if-no-files-found: error
 
+  # Builds and publishes the `-env-loader` variant of the connector image.
+  # Uses the statically-linked binaries produced above + Alpine + jq so that
+  # the Helm chart's external-secrets integration can mount JSON secrets at
+  # /secrets/ and have them exported as env vars before the connector starts.
+  docker-env-loader:
+    name: deploy::docker (env-loader)
+    needs: build-connector-binaries
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Download connector binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+          pattern: mongodb-connector-*
+          merge-multiple: true
+
+      - name: Compute docker tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Mirrors the tag derivation in scripts/publish-docker-image.nix so
+          # the env-loader image tracks the regular image's tag set, with a
+          # `-env-loader` suffix appended to each tag.
+          ref="${GITHUB_REF}"
+          tags=()
+          if [[ "$ref" =~ ^refs/tags/(v.*)$ ]]; then
+            tags+=("${BASH_REMATCH[1]}")
+          elif [[ "$ref" =~ ^refs/heads/(.*)$ ]]; then
+            branch="${BASH_REMATCH[1]}"
+            prefix="dev-${branch}"
+            version=$(TZ=UTC0 git show --quiet \
+              --date='format-local:%Y%m%dT%H%M' \
+              --format="${prefix}-%cd-%h")
+            tags+=("$version" "$prefix")
+          fi
+
+          if [[ ${#tags[@]} -eq 0 ]]; then
+            echo "Ref $ref is not a release tag or branch — skipping push."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          image="ghcr.io/hasura/ndc-mongodb"
+          docker_tags=""
+          for t in "${tags[@]}"; do
+            docker_tags+="${image}:${t}-env-loader"$'\n'
+          done
+          {
+            echo "skip=false"
+            echo "tags<<EOF"
+            echo "${docker_tags}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        if: steps.tags.outputs.skip != 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.tags.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry 📦
+        if: steps.tags.outputs.skip != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push env-loader image
+        if: steps.tags.outputs.skip != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.env-loader
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha,scope=env-loader
+          cache-to: type=gha,mode=max,scope=env-loader
+
   # Builds without nix to get Windows binaries
   build-cli-binaries:
     name: build the CLI binaries

--- a/Dockerfile.env-loader
+++ b/Dockerfile.env-loader
@@ -1,0 +1,49 @@
+# env-loader variant of the MongoDB connector image.
+#
+# The regular connector image is built with Nix (see nix/docker-connector.nix)
+# and has no shell or package manager, so jq and the wrapper script cannot be
+# layered on top of it directly. Instead this Dockerfile starts from Alpine,
+# adds jq, and copies the statically-linked connector binary produced by the
+# `build-connector-binaries` CI job. The wrapper exports key/value pairs from
+# JSON files under /secrets/ as environment variables before exec'ing the
+# connector. Intended for use with the ddn-helm-charts external-secrets
+# integration.
+#
+# Build context expects the binaries `mongodb-connector-x86_64-linux` and
+# `mongodb-connector-aarch64-linux` under `release/`. The build picks the
+# correct one based on the docker buildx `TARGETARCH` value.
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS prep
+
+ARG TARGETARCH
+COPY release/ /release/
+
+# Map docker's TARGETARCH (amd64/arm64) to the rustc triple used in the
+# artifact names.
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) src=/release/mongodb-connector-x86_64-linux ;; \
+      arm64) src=/release/mongodb-connector-aarch64-linux ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    cp "$src" /mongodb-connector; \
+    chmod +x /mongodb-connector
+
+FROM alpine:3.20
+
+RUN apk add --no-cache jq ca-certificates
+
+COPY --from=prep /mongodb-connector /usr/local/bin/mongodb-connector
+COPY scripts/env-loader.sh /usr/local/bin/env-loader
+RUN chmod +x /usr/local/bin/env-loader
+
+# Match the defaults set in nix/docker-connector.nix.
+ENV HASURA_CONFIGURATION_DIRECTORY=/etc/connector \
+    HASURA_CONNECTOR_PORT=8080 \
+    MONGODB_DATABASE_URI=mongodb://localhost/db \
+    OTEL_SERVICE_NAME=mongodb-connector \
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/env-loader", "/usr/local/bin/mongodb-connector"]
+CMD ["serve"]

--- a/scripts/env-loader.sh
+++ b/scripts/env-loader.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Loads key/value pairs from every JSON file in /secrets/ as environment
+# variables, then exec's the original command. Lets the connector consume
+# external secrets (e.g. ESO ExternalSecret) mounted as JSON files without
+# requiring the upstream image to know about that layout.
+set -e
+
+SECRETS_DIR="${SECRETS_DIR:-/secrets}"
+
+if [ -d "$SECRETS_DIR" ]; then
+  for f in "$SECRETS_DIR"/*.json; do
+    [ -f "$f" ] || continue
+    eval "$(jq -r 'to_entries | .[] | "export \(.key)=\(.value | @sh)"' "$f")"
+  done
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.env-loader` for an Alpine-based image that bundles `jq`, the statically-linked `mongodb-connector` binary, and a small wrapper script. The wrapper reads every JSON file in `/secrets/` and exports each key/value pair as an environment variable before exec'ing the connector.
- Adds `scripts/env-loader.sh` (the wrapper).
- Adds a `docker-env-loader` job to `.github/workflows/deploy.yml` that consumes the binaries produced by `build-connector-binaries`, derives the same tag set as `scripts/publish-docker-image.nix`, and pushes a multi-arch image (`linux/amd64` + `linux/arm64`) to `ghcr.io/hasura/ndc-mongodb` with a `-env-loader` suffix on each tag (e.g. `v2.0.1-env-loader`, `dev-main-env-loader`).

## Why

The Nix-built connector image has no shell or package manager, so `jq` and the wrapper can't be layered on top of it directly. The cleanest path is to build a separate Alpine-based image that reuses the same statically-linked binary CI already produces, and publish it as a sibling tag. This is what [ddn-helm-charts PR #58](https://github.com/hasura/ddn-helm-charts/pull/58) expects for its external-secrets integration.

See PromptQL thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/f13889a5-3ff7-4b3f-972f-f883e8994310

## Test plan

- [ ] CI publishes `ghcr.io/hasura/ndc-mongodb:<tag>-env-loader` alongside the existing `<tag>` (both branch and `v*` tag refs).
- [ ] `docker run --rm -v $(pwd)/secret.json:/secrets/secret.json ghcr.io/hasura/ndc-mongodb:<tag>-env-loader env` shows the JSON keys exported as env vars.
- [ ] Multi-arch image works on both `linux/amd64` and `linux/arm64`.
- [ ] Connector starts and serves on `:8080` when given a valid `MONGODB_DATABASE_URI` via the secret.