### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile.env-loader
+++ b/Dockerfile.env-loader
@@ -12,7 +12,7 @@
 # Build context expects the binaries `mongodb-connector-x86_64-linux` and
 # `mongodb-connector-aarch64-linux` under `release/`. The build picks the
 # correct one based on the docker buildx `TARGETARCH` value.
-FROM --platform=$BUILDPLATFORM alpine:3.20 AS prep
+FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3.20-stable AS prep
 
 ARG TARGETARCH
 COPY release/ /release/
@@ -28,7 +28,7 @@ RUN set -eux; \
     cp "$src" /mongodb-connector; \
     chmod +x /mongodb-connector
 
-FROM alpine:3.20
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3.20-stable
 
 RUN apk add --no-cache jq ca-certificates
 


### PR DESCRIPTION
## What

Re-homes base images in `Dockerfile.env-loader` to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images`, replacing direct pulls from upstream Docker Hub. Images are referenced via floating `-stable` aliases, which auto-advance to the latest patched digest of the same version line.

## Why

Hasura policy requires every container deployed in Hasura infra to be pulled from the private Artifact Registry rather than upstream registries (Docker Hub, ghcr.io, gcr.io, quay.io, etc.). Upstream base images are vendored there using a `preserve-source` path layout.

## Exact FROM swaps (`Dockerfile.env-loader`)

- `FROM --platform=$BUILDPLATFORM alpine:3.20 AS prep` → `FROM --platform=$BUILDPLATFORM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3.20-stable AS prep`
- `FROM alpine:3.20` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/alpine:3.20-stable`

The `--platform=$BUILDPLATFORM` prefix and `AS prep` suffix are preserved exactly; only the image reference portion was swapped. No version bumps — same `3.20` line.

## Scope

Part of an org-wide **Phase 1** base-image migration: exact-match swaps to private `-stable` aliases only. No reformatting, no version changes, and no other files (lockfiles, CI configs) touched.
